### PR TITLE
feat(manifests): fixup config and manifests

### DIFF
--- a/manifests/deis-monitor-prometheus-service.yaml
+++ b/manifests/deis-monitor-prometheus-service.yaml
@@ -10,5 +10,6 @@ spec:
     port: 9090
     targetPort: 9090
     protocol: TCP
+  type: NodePort
   selector:
-    name: deis-monitor-prometheus
+    app: deis-monitor-prometheus

--- a/prometheus/rootfs/Dockerfile
+++ b/prometheus/rootfs/Dockerfile
@@ -1,4 +1,4 @@
-FROM prom/prometheus:0.16.1
+FROM prom/prometheus:master
 
 WORKDIR /tmp
 

--- a/prometheus/rootfs/etc/confd/templates/prometheus.yml
+++ b/prometheus/rootfs/etc/confd/templates/prometheus.yml
@@ -18,7 +18,7 @@ scrape_configs:
 - job_name: 'prometheus'
 
   target_groups:
-    - targets: ['localhost:9090']
+  - targets: ['localhost:9090']
 
 - job_name: 'kubernetes-cluster'
 
@@ -34,7 +34,7 @@ scrape_configs:
 
   kubernetes_sd_configs:
   - api_servers:
-    - 'https://kubernetes.default.svc'
+    - 'https://kubernetes.default.svc.cluster.local'
     in_cluster: true
     kubelet_port: 10250
 
@@ -51,38 +51,24 @@ scrape_configs:
     target_label: kubernetes_role
     replacement: $1
 
-# Scrape config for services.
-#
-# The relabeling allows the actual service scrape endpoint to be configured
-# via the following annotations:
-#
-# * `prometheus.io/scrape`: Only scrape services that have a value of `true`
-# * `prometheus.io/scheme`: If the metrics endpoint is secured then you will need
-# to set this to `https` & most likely set the `tls_config` of the scrape config.
-# * `prometheus.io/path`: If the metrics path is not `/metrics` override this.
-# * `prometheus.io/port`: If the metrics are exposed on a different port to the
-# service then set this appropriately.
-- job_name: 'kubernetes-services'
+- job_name: 'kubernetes-service-endpoints'
 
   kubernetes_sd_configs:
   - api_servers:
-    - 'https://kubernetes.default.svc'
+    - 'https://kubernetes.default.svc.cluster.local'
     in_cluster: true
 
   relabel_configs:
-  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
+  - source_labels: [__meta_kubernetes_role, __meta_kubernetes_service_annotation_prometheus_io_scrape]
     action: keep
-    regex: true
+    regex: endpoint;true
   - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
     action: replace
     target_label: __scheme__
     regex: (https?)
-    replacement: $1
   - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
     action: replace
     target_label: __metrics_path__
-    regex: (.+)
-    replacement: $1
   - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
     action: replace
     target_label: __address__
@@ -90,22 +76,56 @@ scrape_configs:
     replacement: $1:$2
   - action: labelmap
     regex: __meta_kubernetes_service_label_(.+)
-    replacement: $1
   - source_labels: [__meta_kubernetes_role]
     action: replace
-    regex: (.+)
     target_label: kubernetes_role
-    replacement: $1
   - source_labels: [__meta_kubernetes_service_namespace]
     action: replace
-    regex: (.+)
     target_label: kubernetes_namespace
-    replacement: $1
   - source_labels: [__meta_kubernetes_service_name]
     action: replace
-    regex: (.+)
     target_label: kubernetes_name
-    replacement: $1
+
+# Example scrape config for probing services via the Blackbox Exporter.
+#
+# The relabeling allows the actual service scrape endpoint to be configured
+# via the following annotations:
+#
+# * `prometheus.io/probe`: Only probe services that have a value of `true`
+- job_name: 'kubernetes-services'
+
+  metrics_path: /probe
+  params:
+    module: [http_2xx]
+
+  kubernetes_sd_configs:
+  - api_servers:
+    - 'https://kubernetes.default.svc.cluster.local'
+    in_cluster: true
+
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_role, __meta_kubernetes_service_annotation_prometheus_io_probe]
+    action: keep
+    regex: service;true
+  - source_labels: []
+    target_label: __address__
+    replacement: prom-blackbox.default.svc:9115
+  - source_labels: [__address__]
+    regex: (.*)(:80)?
+    target_label: __param_target
+  - source_labels: [__param_target]
+    target_label: instance
+  - action: labelmap
+    regex: __meta_kubernetes_service_label_(.+)
+  - source_labels: [__meta_kubernetes_role]
+    action: replace
+    target_label: kubernetes_role
+  - source_labels: [__meta_kubernetes_service_namespace]
+    action: replace
+    target_label: kubernetes_namespace
+  - source_labels: [__meta_kubernetes_service_name]
+    action: replace
+    target_label: kubernetes_name
 
 #  - job_name: 'node-exporter'
 #    scrape_interval: 5s


### PR DESCRIPTION
This just allows the pods to start correctly and be accessible for development, this does not fix alertmanager.
