### PR TITLE
feat: global tags, upgrade to influxdb, upgrade to telegraph

### DIFF
--- a/telegraf/rootfs/Dockerfile
+++ b/telegraf/rootfs/Dockerfile
@@ -1,20 +1,23 @@
-FROM alpine:3.2
+FROM alpine:3.3
 MAINTAINER Jonathan Chauncey "<jchauncey@deis.com>"
 
-ENV TELEGRAF_VERSION "0.10.0_linux_amd64"
+ENV TELEGRAF_VERSION=0.12.0
+RUN \
+    mkdir -p /usr/local/bin/ &&\
+    apk --update add curl &&\
+    curl -SL http://get.influxdb.org/telegraf/telegraf-${TELEGRAF_VERSION}-1_linux_amd64.tar.gz \
+    | tar xzC / &&\
+    apk del --purge curl && \
+    rm -rf /var/cache/apk/* /tmp/* /var/tmp/*
+# Alpine telegraf fix
+RUN mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
 
-RUN apk --update add bash curl
 
-# The download links for the zip of telegraf are broken.
-# So for now Im building this locally and copying it into the build context.
-ADD https://bintray.com/artifact/download/jchauncey/telegraf/telegraf/telegraf /telegraf
-ADD https://github.com/arschles/envtpl/releases/download/0.1.2/envtpl_linux_amd64 /envtpl
+ENV ENVTPL_VERSION=0.1.2
+ADD https://github.com/arschles/envtpl/releases/download/${ENVTPL_VERSION}/envtpl_linux_amd64 /usr/bin/envtpl
+RUN chmod +x /usr/bin/envtpl
 
 COPY start-telegraf /start-telegraf
 COPY config.toml.tpl /config.toml.tpl
-
-RUN chmod +x /telegraf
-RUN chmod +x /envtpl
-RUN chmod +x /start-telegraf
 
 ENTRYPOINT ["/start-telegraf"]

--- a/telegraf/rootfs/config.toml.tpl
+++ b/telegraf/rootfs/config.toml.tpl
@@ -1,6 +1,13 @@
 # Set Tag Configuration
 [tags]
 
+{{ if .GLOBAL_TAGS }}
+[global_tags]
+  {{ range $index, $item := split "," .GLOBAL_TAGS }}
+    {{ $value := split ":" $item }}{{ $value._0 }}={{ $value._1 | quote }}
+  {{end}}
+{{ end }}
+
 # Set Agent Configuration
 [agent]
   interval = {{ default "10s" .AGENT_INTERVAL | quote }}

--- a/telegraf/rootfs/start-telegraf
+++ b/telegraf/rootfs/start-telegraf
@@ -1,19 +1,24 @@
-#!/bin/bash
+#!/bin/sh
+set -e
+
 export PROMETHEUS_BEARER_TOKEN=/var/run/secrets/kubernetes.io/serviceaccount/token
-export TOKEN=$(cat $PROMETHEUS_BEARER_TOKEN)
-export POD_API_URL=https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT/api/v1/namespaces/$POD_NAMESPACE/pods/$HOSTNAME
-export NODE_NAME=$(curl -s $POD_API_URL --header "Authorization: Bearer $TOKEN" --insecure | grep nodeName | cut -c 18- | tr -d '"')
-export AGENT_HOSTNAME=$NODE_NAME
-echo "Setting Agent Hostname to: $AGENT_HOSTNAME"
-export PROMETHEUS_URLS="\"https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT/api/v1/proxy/nodes/$NODE_NAME/metrics\", \"https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT/metrics\""
-echo "Setting PROMETHEUS_URLS to: $PROMETHEUS_URLS"
+if [ -f $PROMETHEUS_BEARER_TOKEN ]; then
+    export TOKEN=$(cat $PROMETHEUS_BEARER_TOKEN)
+    export POD_API_URL=https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT/api/v1/namespaces/$POD_NAMESPACE/pods/$HOSTNAME
+    export NODE_NAME=$(curl -s $POD_API_URL --header "Authorization: Bearer $TOKEN" --insecure | grep nodeName | cut -c 18- | tr -d '"')
+    export AGENT_HOSTNAME=$NODE_NAME
+    echo "Setting Agent Hostname to: $AGENT_HOSTNAME"
+    export PROMETHEUS_URLS="\"https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT/api/v1/proxy/nodes/$NODE_NAME/metrics\", \"https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT/metrics\""
+    echo "Setting PROMETHEUS_URLS to: $PROMETHEUS_URLS"
+fi
 
 echo "Building config.toml!"
-./envtpl -in config.toml.tpl >> config.toml
+envtpl -in config.toml.tpl | sed  '/^$/d' > config.toml
+
 echo "Finished building toml..."
 echo "###########################################"
 echo "###########################################"
-cat config.toml
+cat config.toml 
 echo "###########################################"
 echo "###########################################"
-exec /telegraf -config config.toml
+telegraf -config config.toml -quiet


### PR DESCRIPTION
This contains the following
- Upgrade to InfluxDB 0.11.1 - I was causing crashes in 0.10.x
- Upgrade to Telegraf 0.11.1 - 0.10.x was possibly causing leaked sockets
- Upgrade to Alpine 3.3
- Conversion of envtpl for telegraf to dockerize - this was done to add support for global tag as an environment variable
- Optional disabling of Prometheus integration -  I normally just rebuild and delete the code related to this, but this will allow me to turn it off and make no difference on the Deis side.
- Stripe duplicate blanks lines from the config template that is generated.  - Makes it easier to read
