### PR TITLE
feat(grafana): Use grafana to calc request per second

### DIFF
--- a/grafana/rootfs/dashboards/deis_router.json
+++ b/grafana/rootfs/dashboards/deis_router.json
@@ -2,680 +2,714 @@
   "dashboard": {
     "id": null,
     "title": "Deis Router",
-    "originalTitle": "Deis Router",
-    "tags": [],
-    "style": "dark",
-    "timezone": "browser",
-    "editable": true,
-    "hideControls": false,
-    "sharedCrosshair": false,
-    "rows": [
-      {
-        "collapse": false,
-        "editable": true,
-        "height": "250px",
-        "panels": [
-          {
-            "aliasColors": {},
-            "bars": false,
-            "datasource": null,
-            "editable": true,
-            "error": false,
-            "fill": 1,
-            "grid": {
-              "threshold1": null,
-              "threshold1Color": "rgba(216, 200, 27, 0.27)",
-              "threshold2": null,
-              "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "id": 1,
-            "isNew": true,
-            "legend": {
-              "avg": false,
-              "current": false,
-              "max": false,
-              "min": false,
-              "show": true,
-              "total": false,
-              "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 12,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-              {
-                "alias": "$tag_app",
-                "dsType": "influxdb",
-                "groupBy": [
-                  {
-                    "params": [
-                      "$interval"
-                    ],
-                    "type": "time"
-                  },
-                  {
-                    "params": [
-                      "app"
-                    ],
-                    "type": "tag"
-                  },
-                  {
-                    "params": [
-                      "null"
-                    ],
-                    "type": "fill"
-                  }
-                ],
-                "measurement": "deis_router_response_time_seconds",
-                "policy": "default",
-                "query": "SELECT last(\"value\") FROM \"deis_router_request_time\" WHERE $timeFilter GROUP BY time($interval), \"app\" fill(null)",
-                "refId": "A",
-                "resultFormat": "time_series",
-                "select": [
-                  [
-                    {
-                      "type": "field",
-                      "params": [
-                        "value"
-                      ]
-                    },
-                    {
-                      "type": "mean",
-                      "params": []
-                    }
-                  ]
-                ],
-                "tags": []
-              }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Response Time",
-            "tooltip": {
-              "msResolution": false,
-              "shared": true,
-              "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-              "show": true
-            },
-            "yaxes": [
-              {
-                "format": "s",
-                "logBase": 1,
-                "max": null,
-                "min": null,
-                "show": true
-              },
-              {
-                "format": "short",
-                "logBase": 1,
-                "max": null,
-                "min": null,
-                "show": true
-              }
-            ],
-            "interval": "1s"
-          }
-        ],
-        "title": "Row"
-      },
-      {
-        "collapse": false,
-        "editable": true,
-        "height": "250px",
-        "panels": [
-          {
-            "aliasColors": {},
-            "bars": false,
-            "datasource": null,
-            "editable": true,
-            "error": false,
-            "fill": 1,
-            "grid": {
-              "threshold1": null,
-              "threshold1Color": "rgba(216, 200, 27, 0.27)",
-              "threshold2": null,
-              "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "id": 2,
-            "interval": "1s",
-            "isNew": true,
-            "legend": {
-              "avg": false,
-              "current": false,
-              "max": false,
-              "min": false,
-              "show": true,
-              "total": false,
-              "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 12,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-              {
-                "alias": "$tag_app",
-                "dsType": "influxdb",
-                "groupBy": [
-                  {
-                    "params": [
-                      "$interval"
-                    ],
-                    "type": "time"
-                  },
-                  {
-                    "params": [
-                      "app"
-                    ],
-                    "type": "tag"
-                  },
-                  {
-                    "params": [
-                      "null"
-                    ],
-                    "type": "fill"
-                  }
-                ],
-                "measurement": "deis_router_request_count_seconds",
-                "policy": "default",
-                "query": "SELECT last(\"value\") FROM \"deis_router_request_count\" WHERE $timeFilter GROUP BY time($interval) fill(null)",
-                "refId": "A",
-                "resultFormat": "time_series",
-                "select": [
-                  [
-                    {
-                      "params": [
-                        "value"
-                      ],
-                      "type": "field"
-                    },
-                    {
-                      "params": [],
-                      "type": "last"
-                    },
-                    {
-                      "params": [
-                        "1s"
-                      ],
-                      "type": "non_negative_derivative"
-                    }
-                  ]
-                ],
-                "tags": []
-              }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Request Per Second",
-            "tooltip": {
-              "msResolution": false,
-              "shared": true,
-              "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-              "show": true
-            },
-            "yaxes": [
-              {
-                "format": "ops",
-                "logBase": 1,
-                "max": null,
-                "min": null,
-                "show": true
-              },
-              {
-                "format": "short",
-                "logBase": 1,
-                "max": null,
-                "min": null,
-                "show": true
-              }
-            ]
-          }
-        ],
-        "title": "New row"
-      },
-      {
-        "collapse": false,
-        "editable": true,
-        "height": "250px",
-        "panels": [
-          {
-            "aliasColors": {},
-            "bars": false,
-            "datasource": null,
-            "editable": true,
-            "error": false,
-            "fill": 1,
-            "grid": {
-              "threshold1": null,
-              "threshold1Color": "rgba(216, 200, 27, 0.27)",
-              "threshold2": null,
-              "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "id": 3,
-            "interval": "30s",
-            "isNew": true,
-            "legend": {
-              "avg": false,
-              "current": false,
-              "max": false,
-              "min": false,
-              "show": true,
-              "total": false,
-              "values": false
-            },
-            "lines": true,
-            "linewidth": 3,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-              {
-                "alias": "user",
-                "color": "#CCA300",
-                "fill": 3
-              },
-              {
-                "alias": "/cpu/",
-                "fill": 3
-              },
-              {
-                "alias": "system",
-                "color": "#890F02",
-                "fill": 3
-              }
-            ],
-            "span": 12,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-              {
-                "alias": "user",
-                "dsType": "influxdb",
-                "groupBy": [
-                  {
-                    "params": [
-                      "$interval"
-                    ],
-                    "type": "time"
-                  },
-                  {
-                    "params": [
-                      "null"
-                    ],
-                    "type": "fill"
-                  }
-                ],
-                "measurement": "container_cpu_user_seconds_total",
-                "policy": "default",
-                "refId": "A",
-                "resultFormat": "time_series",
-                "select": [
-                  [
-                    {
-                      "params": [
-                        "counter"
-                      ],
-                      "type": "field"
-                    },
-                    {
-                      "params": [],
-                      "type": "last"
-                    },
-                    {
-                      "params": [
-                        "10s"
-                      ],
-                      "type": "derivative"
-                    }
-                  ]
-                ],
-                "tags": [
-                  {
-                    "key": "io_kubernetes_container_name",
-                    "operator": "=",
-                    "value": "deis-router"
-                  }
-                ]
-              },
-              {
-                "alias": "$tag_cpu",
-                "dsType": "influxdb",
-                "groupBy": [
-                  {
-                    "params": [
-                      "$interval"
-                    ],
-                    "type": "time"
-                  },
-                  {
-                    "params": [
-                      "cpu"
-                    ],
-                    "type": "tag"
-                  },
-                  {
-                    "params": [
-                      "null"
-                    ],
-                    "type": "fill"
-                  }
-                ],
-                "measurement": "container_cpu_usage_seconds_total",
-                "policy": "default",
-                "refId": "B",
-                "resultFormat": "time_series",
-                "select": [
-                  [
-                    {
-                      "params": [
-                        "counter"
-                      ],
-                      "type": "field"
-                    },
-                    {
-                      "params": [],
-                      "type": "last"
-                    },
-                    {
-                      "params": [
-                        "10s"
-                      ],
-                      "type": "derivative"
-                    }
-                  ]
-                ],
-                "tags": [
-                  {
-                    "key": "io_kubernetes_container_name",
-                    "operator": "=",
-                    "value": "deis-router"
-                  }
-                ]
-              },
-              {
-                "alias": "system",
-                "dsType": "influxdb",
-                "groupBy": [
-                  {
-                    "params": [
-                      "$interval"
-                    ],
-                    "type": "time"
-                  },
-                  {
-                    "params": [
-                      "null"
-                    ],
-                    "type": "fill"
-                  }
-                ],
-                "hide": false,
-                "measurement": "container_cpu_system_seconds_total",
-                "policy": "default",
-                "refId": "C",
-                "resultFormat": "time_series",
-                "select": [
-                  [
-                    {
-                      "params": [
-                        "value"
-                      ],
-                      "type": "field"
-                    },
-                    {
-                      "params": [],
-                      "type": "last"
-                    },
-                    {
-                      "params": [
-                        "10s"
-                      ],
-                      "type": "derivative"
-                    }
-                  ]
-                ],
-                "tags": [
-                  {
-                    "key": "io_kubernetes_container_name",
-                    "operator": "=",
-                    "value": "deis-router"
-                  }
-                ]
-              }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "CPU Usage",
-            "tooltip": {
-              "msResolution": false,
-              "shared": true,
-              "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-              "show": true
-            },
-            "yaxes": [
-              {
-                "format": "s",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": null,
-                "show": true
-              },
-              {
-                "format": "short",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": null,
-                "show": true
-              }
-            ]
-          }
-        ],
-        "title": "New row"
-      },
-      {
-        "collapse": false,
-        "editable": true,
-        "height": "250px",
-        "panels": [
-          {
-            "aliasColors": {},
-            "bars": false,
-            "datasource": null,
-            "editable": true,
-            "error": false,
-            "fill": 1,
-            "grid": {
-              "threshold1": null,
-              "threshold1Color": "rgba(216, 200, 27, 0.27)",
-              "threshold2": null,
-              "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "id": 7,
-            "isNew": true,
-            "legend": {
-              "avg": false,
-              "current": false,
-              "max": false,
-              "min": false,
-              "show": true,
-              "total": false,
-              "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 12,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-              {
-                "alias": "$tag_image",
-                "dsType": "influxdb",
-                "groupBy": [
-                  {
-                    "params": [
-                      "$interval"
-                    ],
-                    "type": "time"
-                  },
-                  {
-                    "params": [
-                      "image"
-                    ],
-                    "type": "tag"
-                  },
-                  {
-                    "params": [
-                      "null"
-                    ],
-                    "type": "fill"
-                  }
-                ],
-                "measurement": "container_memory_usage_bytes",
-                "policy": "default",
-                "refId": "A",
-                "resultFormat": "time_series",
-                "select": [
-                  [
-                    {
-                      "params": [
-                        "gauge"
-                      ],
-                      "type": "field"
-                    },
-                    {
-                      "params": [],
-                      "type": "last"
-                    }
-                  ]
-                ],
-                "tags": [
-                  {
-                    "key": "io_kubernetes_container_name",
-                    "operator": "=",
-                    "value": "deis-router"
-                  }
-                ]
-              }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Memory Usage",
-            "tooltip": {
-              "msResolution": false,
-              "shared": true,
-              "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-              "show": true
-            },
-            "yaxes": [
-              {
-                "format": "bytes",
-                "label": "",
-                "logBase": 32,
-                "max": null,
-                "min": null,
-                "show": true
-              },
-              {
-                "format": "short",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": null,
-                "show": true
-              }
-            ]
-          }
-        ],
-        "title": "New row"
-      },
-      {
-        "title": "New row",
-        "height": "250px",
-        "editable": true,
-        "collapse": false,
-        "panels": []
-      }
-    ],
-    "time": {
-      "from": "now-5m",
-      "to": "now"
-    },
-    "timepicker": {
-      "now": true,
-      "refresh_intervals": [
-        "5s",
-        "10s",
-        "30s",
-        "1m",
-        "5m",
-        "15m",
-        "30m",
-        "1h",
-        "2h",
-        "1d"
-      ],
-      "time_options": [
-        "5m",
-        "15m",
-        "1h",
-        "6h",
-        "12h",
-        "24h",
-        "2d",
-        "7d",
-        "30d"
-      ]
-    },
-    "templating": {
-      "list": []
-    },
-    "annotations": {
-      "list": []
-    },
-    "refresh": "5s",
-    "schemaVersion": 12,
-    "version": 1,
-    "links": []
+   "originalTitle": "Deis Router",
+   "tags": [],
+   "style": "dark",
+   "timezone": "browser",
+   "editable": true,
+   "hideControls": false,
+   "sharedCrosshair": false,
+   "rows": [
+     {
+       "collapse": false,
+       "editable": true,
+       "height": "250px",
+       "panels": [
+         {
+           "aliasColors": {},
+           "bars": false,
+           "datasource": null,
+           "editable": true,
+           "error": false,
+           "fill": 1,
+           "grid": {
+             "threshold1": null,
+             "threshold1Color": "rgba(216, 200, 27, 0.27)",
+             "threshold2": null,
+             "threshold2Color": "rgba(234, 112, 112, 0.22)"
+           },
+           "id": 1,
+           "isNew": true,
+           "legend": {
+             "avg": false,
+             "current": false,
+             "max": false,
+             "min": false,
+             "show": true,
+             "total": false,
+             "values": false
+           },
+           "lines": true,
+           "linewidth": 2,
+           "links": [],
+           "nullPointMode": "connected",
+           "percentage": false,
+           "pointradius": 5,
+           "points": false,
+           "renderer": "flot",
+           "seriesOverrides": [],
+           "span": 12,
+           "stack": false,
+           "steppedLine": false,
+           "targets": [
+             {
+               "alias": "$tag_app",
+               "dsType": "influxdb",
+               "groupBy": [
+                 {
+                   "params": [
+                     "$interval"
+                   ],
+                   "type": "time"
+                 },
+                 {
+                   "params": [
+                     "app"
+                   ],
+                   "type": "tag"
+                 },
+                 {
+                   "params": [
+                     "null"
+                   ],
+                   "type": "fill"
+                 }
+               ],
+               "measurement": "deis_router_response_time_seconds",
+               "policy": "default",
+               "query": "SELECT last(\"value\") FROM \"deis_router_request_time\" WHERE $timeFilter GROUP BY time($interval), \"app\" fill(null)",
+               "refId": "A",
+               "resultFormat": "time_series",
+               "select": [
+                 [
+                   {
+                     "type": "field",
+                     "params": [
+                       "value"
+                     ]
+                   },
+                   {
+                     "type": "mean",
+                     "params": []
+                   }
+                 ]
+               ],
+               "tags": []
+             }
+           ],
+           "timeFrom": null,
+           "timeShift": null,
+           "title": "Response Time",
+           "tooltip": {
+             "msResolution": false,
+             "shared": true,
+             "value_type": "cumulative"
+           },
+           "type": "graph",
+           "xaxis": {
+             "show": true
+           },
+           "yaxes": [
+             {
+               "format": "s",
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+             },
+             {
+               "format": "short",
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+             }
+           ],
+           "interval": "1s"
+         }
+       ],
+       "title": "Row"
+     },
+     {
+       "collapse": false,
+       "editable": true,
+       "height": "250px",
+       "panels": [
+         {
+           "aliasColors": {},
+           "bars": false,
+           "datasource": null,
+           "editable": true,
+           "error": false,
+           "fill": 3,
+           "grid": {
+             "threshold1": null,
+             "threshold1Color": "rgba(216, 200, 27, 0.27)",
+             "threshold2": null,
+             "threshold2Color": "rgba(234, 112, 112, 0.22)"
+           },
+           "id": 2,
+           "interval": "1s",
+           "isNew": true,
+           "legend": {
+             "avg": false,
+             "current": false,
+             "max": false,
+             "min": false,
+             "show": true,
+             "total": false,
+             "values": false
+           },
+           "lines": true,
+           "linewidth": 2,
+           "links": [],
+           "nullPointMode": "connected",
+           "percentage": false,
+           "pointradius": 5,
+           "points": false,
+           "renderer": "flot",
+           "seriesOverrides": [
+             {
+               "alias": "/aggregate/",
+               "color": "#890F02",
+               "fill": 3
+             }
+           ],
+           "span": 12,
+           "stack": false,
+           "steppedLine": false,
+           "targets": [
+             {
+               "alias": "$tag_app",
+               "dsType": "influxdb",
+               "groupBy": [
+                 {
+                   "params": [
+                     "$interval"
+                   ],
+                   "type": "time"
+                 },
+                 {
+                   "params": [
+                     "app"
+                   ],
+                   "type": "tag"
+                 },
+                 {
+                   "params": [
+                     "null"
+                   ],
+                   "type": "fill"
+                 }
+               ],
+               "measurement": "deis_router_response_time_seconds",
+               "policy": "default",
+               "query": "SELECT last(\"value\") FROM \"deis_router_request_count\" WHERE $timeFilter GROUP BY time($interval) fill(null)",
+               "refId": "A",
+               "resultFormat": "time_series",
+               "select": [
+                 [
+                   {
+                     "type": "field",
+                     "params": [
+                       "value"
+                     ]
+                   },
+                   {
+                     "type": "count",
+                     "params": []
+                   }
+                 ]
+               ],
+               "tags": [],
+               "hide": false
+             },
+             {
+               "alias": "aggregate",
+               "dsType": "influxdb",
+               "groupBy": [
+                 {
+                   "params": [
+                     "$interval"
+                   ],
+                   "type": "time"
+                 },
+                 {
+                   "params": [
+                     "null"
+                   ],
+                   "type": "fill"
+                 }
+               ],
+               "measurement": "deis_router_response_time_seconds",
+               "policy": "default",
+               "query": "SELECT last(\"value\") FROM \"deis_router_request_count\" WHERE $timeFilter GROUP BY time($interval) fill(null)",
+               "refId": "B",
+               "resultFormat": "time_series",
+               "select": [
+                 [
+                   {
+                     "type": "field",
+                     "params": [
+                       "value"
+                     ]
+                   },
+                   {
+                     "type": "count",
+                     "params": []
+                   }
+                 ]
+               ],
+               "tags": [],
+               "hide": false
+             }
+           ],
+           "timeFrom": null,
+           "timeShift": null,
+           "title": "Request Per Second",
+           "tooltip": {
+             "msResolution": false,
+             "shared": true,
+             "value_type": "cumulative"
+           },
+           "type": "graph",
+           "xaxis": {
+             "show": true
+           },
+           "yaxes": [
+             {
+               "format": "ops",
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true,
+               "label": "req/sec"
+             },
+             {
+               "format": "short",
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": false
+             }
+           ]
+         }
+       ],
+       "title": "New row"
+     },
+     {
+       "collapse": false,
+       "editable": true,
+       "height": "250px",
+       "panels": [
+         {
+           "aliasColors": {},
+           "bars": false,
+           "datasource": null,
+           "editable": true,
+           "error": false,
+           "fill": 1,
+           "grid": {
+             "threshold1": null,
+             "threshold1Color": "rgba(216, 200, 27, 0.27)",
+             "threshold2": null,
+             "threshold2Color": "rgba(234, 112, 112, 0.22)"
+           },
+           "id": 3,
+           "interval": "30s",
+           "isNew": true,
+           "legend": {
+             "avg": false,
+             "current": false,
+             "max": false,
+             "min": false,
+             "show": true,
+             "total": false,
+             "values": false
+           },
+           "lines": true,
+           "linewidth": 3,
+           "links": [],
+           "nullPointMode": "connected",
+           "percentage": false,
+           "pointradius": 5,
+           "points": false,
+           "renderer": "flot",
+           "seriesOverrides": [
+             {
+               "alias": "user",
+               "color": "#CCA300",
+               "fill": 3
+             },
+             {
+               "alias": "/cpu/",
+               "fill": 3
+             },
+             {
+               "alias": "system",
+               "color": "#890F02",
+               "fill": 3
+             }
+           ],
+           "span": 12,
+           "stack": false,
+           "steppedLine": false,
+           "targets": [
+             {
+               "alias": "user",
+               "dsType": "influxdb",
+               "groupBy": [
+                 {
+                   "params": [
+                     "$interval"
+                   ],
+                   "type": "time"
+                 },
+                 {
+                   "params": [
+                     "null"
+                   ],
+                   "type": "fill"
+                 }
+               ],
+               "measurement": "container_cpu_user_seconds_total",
+               "policy": "default",
+               "refId": "A",
+               "resultFormat": "time_series",
+               "select": [
+                 [
+                   {
+                     "params": [
+                       "counter"
+                     ],
+                     "type": "field"
+                   },
+                   {
+                     "params": [],
+                     "type": "last"
+                   },
+                   {
+                     "params": [
+                       "10s"
+                     ],
+                     "type": "derivative"
+                   }
+                 ]
+               ],
+               "tags": [
+                 {
+                   "key": "io_kubernetes_container_name",
+                   "operator": "=",
+                   "value": "deis-router"
+                 }
+               ]
+             },
+             {
+               "alias": "$tag_cpu",
+               "dsType": "influxdb",
+               "groupBy": [
+                 {
+                   "params": [
+                     "$interval"
+                   ],
+                   "type": "time"
+                 },
+                 {
+                   "params": [
+                     "cpu"
+                   ],
+                   "type": "tag"
+                 },
+                 {
+                   "params": [
+                     "null"
+                   ],
+                   "type": "fill"
+                 }
+               ],
+               "measurement": "container_cpu_usage_seconds_total",
+               "policy": "default",
+               "refId": "B",
+               "resultFormat": "time_series",
+               "select": [
+                 [
+                   {
+                     "params": [
+                       "counter"
+                     ],
+                     "type": "field"
+                   },
+                   {
+                     "params": [],
+                     "type": "last"
+                   },
+                   {
+                     "params": [
+                       "10s"
+                     ],
+                     "type": "derivative"
+                   }
+                 ]
+               ],
+               "tags": [
+                 {
+                   "key": "io_kubernetes_container_name",
+                   "operator": "=",
+                   "value": "deis-router"
+                 }
+               ]
+             },
+             {
+               "alias": "system",
+               "dsType": "influxdb",
+               "groupBy": [
+                 {
+                   "params": [
+                     "$interval"
+                   ],
+                   "type": "time"
+                 },
+                 {
+                   "params": [
+                     "null"
+                   ],
+                   "type": "fill"
+                 }
+               ],
+               "hide": false,
+               "measurement": "container_cpu_system_seconds_total",
+               "policy": "default",
+               "refId": "C",
+               "resultFormat": "time_series",
+               "select": [
+                 [
+                   {
+                     "params": [
+                       "value"
+                     ],
+                     "type": "field"
+                   },
+                   {
+                     "params": [],
+                     "type": "last"
+                   },
+                   {
+                     "params": [
+                       "10s"
+                     ],
+                     "type": "derivative"
+                   }
+                 ]
+               ],
+               "tags": [
+                 {
+                   "key": "io_kubernetes_container_name",
+                   "operator": "=",
+                   "value": "deis-router"
+                 }
+               ]
+             }
+           ],
+           "timeFrom": null,
+           "timeShift": null,
+           "title": "CPU Usage",
+           "tooltip": {
+             "msResolution": false,
+             "shared": true,
+             "value_type": "cumulative"
+           },
+           "type": "graph",
+           "xaxis": {
+             "show": true
+           },
+           "yaxes": [
+             {
+               "format": "s",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+             },
+             {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+             }
+           ]
+         }
+       ],
+       "title": "New row"
+     },
+     {
+       "collapse": false,
+       "editable": true,
+       "height": "250px",
+       "panels": [
+         {
+           "aliasColors": {},
+           "bars": false,
+           "datasource": null,
+           "editable": true,
+           "error": false,
+           "fill": 1,
+           "grid": {
+             "threshold1": null,
+             "threshold1Color": "rgba(216, 200, 27, 0.27)",
+             "threshold2": null,
+             "threshold2Color": "rgba(234, 112, 112, 0.22)"
+           },
+           "id": 7,
+           "isNew": true,
+           "legend": {
+             "avg": false,
+             "current": false,
+             "max": false,
+             "min": false,
+             "show": true,
+             "total": false,
+             "values": false
+           },
+           "lines": true,
+           "linewidth": 2,
+           "links": [],
+           "nullPointMode": "connected",
+           "percentage": false,
+           "pointradius": 5,
+           "points": false,
+           "renderer": "flot",
+           "seriesOverrides": [],
+           "span": 12,
+           "stack": false,
+           "steppedLine": false,
+           "targets": [
+             {
+               "alias": "$tag_image",
+               "dsType": "influxdb",
+               "groupBy": [
+                 {
+                   "params": [
+                     "$interval"
+                   ],
+                   "type": "time"
+                 },
+                 {
+                   "params": [
+                     "image"
+                   ],
+                   "type": "tag"
+                 },
+                 {
+                   "params": [
+                     "null"
+                   ],
+                   "type": "fill"
+                 }
+               ],
+               "measurement": "container_memory_usage_bytes",
+               "policy": "default",
+               "refId": "A",
+               "resultFormat": "time_series",
+               "select": [
+                 [
+                   {
+                     "params": [
+                       "gauge"
+                     ],
+                     "type": "field"
+                   },
+                   {
+                     "params": [],
+                     "type": "last"
+                   }
+                 ]
+               ],
+               "tags": [
+                 {
+                   "key": "io_kubernetes_container_name",
+                   "operator": "=",
+                   "value": "deis-router"
+                 }
+               ]
+             }
+           ],
+           "timeFrom": null,
+           "timeShift": null,
+           "title": "Memory Usage",
+           "tooltip": {
+             "msResolution": false,
+             "shared": true,
+             "value_type": "cumulative"
+           },
+           "type": "graph",
+           "xaxis": {
+             "show": true
+           },
+           "yaxes": [
+             {
+               "format": "bytes",
+               "label": "",
+               "logBase": 32,
+               "max": null,
+               "min": null,
+               "show": true
+             },
+             {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+             }
+           ]
+         }
+       ],
+       "title": "New row"
+     }
+   ],
+   "time": {
+     "from": "now-5m",
+     "to": "now"
+   },
+   "timepicker": {
+     "now": true,
+     "refresh_intervals": [
+       "5s",
+       "10s",
+       "30s",
+       "1m",
+       "5m",
+       "15m",
+       "30m",
+       "1h",
+       "2h",
+       "1d"
+     ],
+     "time_options": [
+       "5m",
+       "15m",
+       "1h",
+       "6h",
+       "12h",
+       "24h",
+       "2d",
+       "7d",
+       "30d"
+     ]
+   },
+   "templating": {
+     "list": []
+   },
+   "annotations": {
+     "list": []
+   },
+   "refresh": "5s",
+   "schemaVersion": 12,
+   "version": 1,
+   "links": []
   }
 }

--- a/grafana/rootfs/dashboards/influx.json
+++ b/grafana/rootfs/dashboards/influx.json
@@ -2,437 +2,651 @@
   "dashboard": {
     "id": null,
     "title": "Influx",
-    "originalTitle": "Influx",
-    "tags": [],
-    "style": "dark",
-    "timezone": "browser",
-    "editable": true,
-    "hideControls": false,
-    "sharedCrosshair": false,
-    "rows": [
-      {
-        "title": "New row",
-        "height": "250px",
-        "editable": true,
-        "collapse": false,
-        "panels": [
-          {
-            "title": "Number of Measurements",
-            "error": false,
-            "span": 6,
-            "editable": true,
-            "type": "singlestat",
-            "isNew": true,
-            "id": 2,
-            "targets": [
-              {
-                "policy": "default",
-                "dsType": "influxdb",
-                "resultFormat": "time_series",
-                "tags": [],
-                "groupBy": [
-                  {
-                    "type": "time",
-                    "params": [
-                      "$interval"
-                    ]
-                  },
-                  {
-                    "type": "fill",
-                    "params": [
-                      "null"
-                    ]
-                  }
-                ],
-                "select": [
-                  [
-                    {
-                      "type": "field",
-                      "params": [
-                        "numMeasurements"
-                      ]
-                    },
-                    {
-                      "type": "last",
-                      "params": []
-                    }
-                  ]
-                ],
-                "refId": "A",
-                "measurement": "influxdb_database",
-                "alias": ""
-              }
-            ],
-            "links": [],
-            "datasource": null,
-            "maxDataPoints": 100,
-            "interval": null,
-            "cacheTimeout": null,
-            "format": "none",
-            "prefix": "",
-            "postfix": "",
-            "nullText": null,
-            "valueMaps": [
-              {
-                "value": "null",
-                "op": "=",
-                "text": "N/A"
-              }
-            ],
-            "nullPointMode": "connected",
-            "valueName": "avg",
-            "prefixFontSize": "50%",
-            "valueFontSize": "200%",
-            "postfixFontSize": "50%",
-            "thresholds": "",
-            "colorBackground": false,
-            "colorValue": false,
-            "colors": [
-              "rgba(245, 54, 54, 0.9)",
-              "rgba(237, 129, 40, 0.89)",
-              "rgba(50, 172, 45, 0.97)"
-            ],
-            "sparkline": {
-              "show": false,
-              "full": false,
-              "lineColor": "rgb(31, 120, 193)",
-              "fillColor": "rgba(31, 118, 189, 0.18)"
-            },
-            "gauge": {
-              "show": false,
-              "minValue": 0,
-              "maxValue": 100,
-              "thresholdMarkers": true,
-              "thresholdLabels": false
-            }
-          },
-          {
-            "title": "Number of Series",
-            "error": false,
-            "span": 6,
-            "editable": true,
-            "type": "singlestat",
-            "isNew": true,
-            "id": 3,
-            "targets": [
-              {
-                "policy": "default",
-                "dsType": "influxdb",
-                "resultFormat": "time_series",
-                "tags": [],
-                "groupBy": [
-                  {
-                    "type": "time",
-                    "params": [
-                      "$interval"
-                    ]
-                  },
-                  {
-                    "type": "fill",
-                    "params": [
-                      "null"
-                    ]
-                  }
-                ],
-                "select": [
-                  [
-                    {
-                      "type": "field",
-                      "params": [
-                        "numSeries"
-                      ]
-                    },
-                    {
-                      "type": "last",
-                      "params": []
-                    }
-                  ]
-                ],
-                "refId": "A",
-                "measurement": "influxdb_database",
-                "alias": ""
-              }
-            ],
-            "links": [],
-            "datasource": null,
-            "maxDataPoints": 100,
-            "interval": null,
-            "cacheTimeout": null,
-            "format": "none",
-            "prefix": "",
-            "postfix": "",
-            "nullText": null,
-            "valueMaps": [
-              {
-                "value": "null",
-                "op": "=",
-                "text": "N/A"
-              }
-            ],
-            "nullPointMode": "connected",
-            "valueName": "avg",
-            "prefixFontSize": "50%",
-            "valueFontSize": "200%",
-            "postfixFontSize": "50%",
-            "thresholds": "",
-            "colorBackground": false,
-            "colorValue": false,
-            "colors": [
-              "rgba(245, 54, 54, 0.9)",
-              "rgba(237, 129, 40, 0.89)",
-              "rgba(50, 172, 45, 0.97)"
-            ],
-            "sparkline": {
-              "show": false,
-              "full": false,
-              "lineColor": "rgb(31, 120, 193)",
-              "fillColor": "rgba(31, 118, 189, 0.18)"
-            },
-            "gauge": {
-              "show": false,
-              "minValue": 0,
-              "maxValue": 100,
-              "thresholdMarkers": true,
-              "thresholdLabels": false
-            }
-          }
-        ]
-      },
-      {
-        "collapse": false,
-        "editable": true,
-        "height": "250px",
-        "panels": [
-          {
-            "aliasColors": {},
-            "bars": false,
-            "datasource": null,
-            "editable": true,
-            "error": false,
-            "fill": 1,
-            "grid": {
-              "threshold1": null,
-              "threshold1Color": "rgba(216, 200, 27, 0.27)",
-              "threshold2": null,
-              "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "id": 1,
-            "isNew": true,
-            "legend": {
-              "alignAsTable": true,
-              "avg": false,
-              "current": false,
-              "max": false,
-              "min": false,
-              "rightSide": true,
-              "show": false,
-              "total": false,
-              "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-              {
-                "alias": "/Read/",
-                "color": "#508642",
-                "fill": 4
-              },
-              {
-                "alias": "/Write/",
-                "color": "#65C5DB",
-                "fill": 4
-              }
-            ],
-            "span": 12,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-              {
-                "alias": "Read - $tag_host",
-                "dsType": "influxdb",
-                "groupBy": [
-                  {
-                    "params": [
-                      "$interval"
-                    ],
-                    "type": "time"
-                  },
-                  {
-                    "params": [
-                      "host"
-                    ],
-                    "type": "tag"
-                  },
-                  {
-                    "params": [
-                      "null"
-                    ],
-                    "type": "fill"
-                  }
-                ],
-                "measurement": "influxdb_httpd",
-                "query": "SELECT non_negative_derivative(last(\"queryReq\"), 1s) FROM \"influxdb_httpd\" WHERE $timeFilter GROUP BY time($interval), \"host\" fill(null)",
-                "refId": "A",
-                "resultFormat": "time_series",
-                "select": [
-                  [
-                    {
-                      "params": [
-                        "queryReq"
-                      ],
-                      "type": "field"
-                    },
-                    {
-                      "params": [],
-                      "type": "last"
-                    },
-                    {
-                      "params": [
-                        "1s"
-                      ],
-                      "type": "non_negative_derivative"
-                    }
-                  ]
-                ],
-                "tags": [],
-                "policy": "default"
-              },
-              {
-                "alias": "Write - $tag_host",
-                "dsType": "influxdb",
-                "groupBy": [
-                  {
-                    "params": [
-                      "$interval"
-                    ],
-                    "type": "time"
-                  },
-                  {
-                    "params": [
-                      "host"
-                    ],
-                    "type": "tag"
-                  },
-                  {
-                    "params": [
-                      "null"
-                    ],
-                    "type": "fill"
-                  }
-                ],
-                "measurement": "influxdb_httpd",
-                "query": "SELECT non_negative_derivative(last(\"queryReq\"), 1s) FROM \"influxdb_httpd\" WHERE $timeFilter GROUP BY time($interval), \"host\" fill(null)",
-                "refId": "B",
-                "resultFormat": "time_series",
-                "select": [
-                  [
-                    {
-                      "params": [
-                        "writeReq"
-                      ],
-                      "type": "field"
-                    },
-                    {
-                      "params": [],
-                      "type": "last"
-                    },
-                    {
-                      "params": [
-                        "1s"
-                      ],
-                      "type": "non_negative_derivative"
-                    }
-                  ]
-                ],
-                "tags": [],
-                "policy": "default"
-              }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "HTTP Requests Per Second",
-            "tooltip": {
-              "shared": true,
-              "value_type": "cumulative",
-              "msResolution": false
-            },
-            "type": "graph",
-            "yaxes": [
-              {
-                "show": true,
-                "min": null,
-                "max": null,
-                "logBase": 1,
-                "format": "ops"
-              },
-              {
-                "show": true,
-                "min": null,
-                "max": null,
-                "logBase": 1,
-                "format": "short"
-              }
-            ],
-            "xaxis": {
-              "show": true
-            },
-            "interval": "1s"
-          }
-        ],
-        "title": "Row"
-      },
-      {
-        "title": "New row",
-        "height": "250px",
-        "editable": true,
-        "collapse": false,
-        "panels": []
-      }
-    ],
-    "time": {
-      "from": "now-5m",
-      "to": "now"
-    },
-    "timepicker": {
-      "now": true,
-      "refresh_intervals": [
-        "5s",
-        "10s",
-        "30s",
-        "1m",
-        "5m",
-        "15m",
-        "30m",
-        "1h",
-        "2h",
-        "1d"
-      ],
-      "time_options": [
-        "5m",
-        "15m",
-        "1h",
-        "6h",
-        "12h",
-        "24h",
-        "2d",
-        "7d",
-        "30d"
-      ]
-    },
-    "templating": {
-      "list": []
-    },
-    "annotations": {
-      "list": []
-    },
-    "schemaVersion": 12,
-    "version": 0,
-    "links": []
-  }
+     "originalTitle": "Influx",
+     "tags": [],
+     "style": "dark",
+     "timezone": "browser",
+     "editable": true,
+     "hideControls": false,
+     "sharedCrosshair": false,
+     "rows": [
+       {
+         "collapse": false,
+         "editable": true,
+         "height": "250px",
+         "panels": [
+           {
+             "cacheTimeout": null,
+             "colorBackground": false,
+             "colorValue": false,
+             "colors": [
+               "rgba(245, 54, 54, 0.9)",
+               "rgba(237, 129, 40, 0.89)",
+               "rgba(50, 172, 45, 0.97)"
+             ],
+             "datasource": null,
+             "editable": true,
+             "error": false,
+             "format": "none",
+             "gauge": {
+               "maxValue": 100,
+               "minValue": 0,
+               "show": false,
+               "thresholdLabels": false,
+               "thresholdMarkers": true
+             },
+             "id": 2,
+             "interval": null,
+             "isNew": true,
+             "links": [],
+             "maxDataPoints": 100,
+             "nullPointMode": "connected",
+             "nullText": null,
+             "postfix": "",
+             "postfixFontSize": "50%",
+             "prefix": "",
+             "prefixFontSize": "50%",
+             "span": 6,
+             "sparkline": {
+               "fillColor": "rgba(31, 118, 189, 0.18)",
+               "full": false,
+               "lineColor": "rgb(31, 120, 193)",
+               "show": false
+             },
+             "targets": [
+               {
+                 "alias": "",
+                 "dsType": "influxdb",
+                 "groupBy": [
+                   {
+                     "params": [
+                       "$interval"
+                     ],
+                     "type": "time"
+                   },
+                   {
+                     "params": [
+                       "null"
+                     ],
+                     "type": "fill"
+                   }
+                 ],
+                 "measurement": "influxdb_database",
+                 "policy": "default",
+                 "refId": "A",
+                 "resultFormat": "time_series",
+                 "select": [
+                   [
+                     {
+                       "params": [
+                         "numMeasurements"
+                       ],
+                       "type": "field"
+                     },
+                     {
+                       "params": [],
+                       "type": "last"
+                     }
+                   ]
+                 ],
+                 "tags": []
+               }
+             ],
+             "thresholds": "",
+             "title": "Number of Measurements",
+             "type": "singlestat",
+             "valueFontSize": "200%",
+             "valueMaps": [
+               {
+                 "op": "=",
+                 "text": "N/A",
+                 "value": "null"
+               }
+             ],
+             "valueName": "avg"
+           },
+           {
+             "cacheTimeout": null,
+             "colorBackground": false,
+             "colorValue": false,
+             "colors": [
+               "rgba(245, 54, 54, 0.9)",
+               "rgba(237, 129, 40, 0.89)",
+               "rgba(50, 172, 45, 0.97)"
+             ],
+             "datasource": null,
+             "editable": true,
+             "error": false,
+             "format": "none",
+             "gauge": {
+               "maxValue": 100,
+               "minValue": 0,
+               "show": false,
+               "thresholdLabels": false,
+               "thresholdMarkers": true
+             },
+             "id": 3,
+             "interval": null,
+             "isNew": true,
+             "links": [],
+             "maxDataPoints": 100,
+             "nullPointMode": "connected",
+             "nullText": null,
+             "postfix": "",
+             "postfixFontSize": "50%",
+             "prefix": "",
+             "prefixFontSize": "50%",
+             "span": 6,
+             "sparkline": {
+               "fillColor": "rgba(31, 118, 189, 0.18)",
+               "full": false,
+               "lineColor": "rgb(31, 120, 193)",
+               "show": false
+             },
+             "targets": [
+               {
+                 "alias": "",
+                 "dsType": "influxdb",
+                 "groupBy": [
+                   {
+                     "params": [
+                       "$interval"
+                     ],
+                     "type": "time"
+                   },
+                   {
+                     "params": [
+                       "null"
+                     ],
+                     "type": "fill"
+                   }
+                 ],
+                 "measurement": "influxdb_database",
+                 "policy": "default",
+                 "refId": "A",
+                 "resultFormat": "time_series",
+                 "select": [
+                   [
+                     {
+                       "params": [
+                         "numSeries"
+                       ],
+                       "type": "field"
+                     },
+                     {
+                       "params": [],
+                       "type": "last"
+                     }
+                   ]
+                 ],
+                 "tags": []
+               }
+             ],
+             "thresholds": "",
+             "title": "Number of Series",
+             "type": "singlestat",
+             "valueFontSize": "200%",
+             "valueMaps": [
+               {
+                 "op": "=",
+                 "text": "N/A",
+                 "value": "null"
+               }
+             ],
+             "valueName": "avg"
+           }
+         ],
+         "title": "New row"
+       },
+       {
+         "collapse": false,
+         "editable": true,
+         "height": "250px",
+         "panels": [
+           {
+             "aliasColors": {},
+             "bars": false,
+             "datasource": null,
+             "editable": true,
+             "error": false,
+             "fill": 1,
+             "grid": {
+               "threshold1": null,
+               "threshold1Color": "rgba(216, 200, 27, 0.27)",
+               "threshold2": null,
+               "threshold2Color": "rgba(234, 112, 112, 0.22)"
+             },
+             "id": 1,
+             "interval": "",
+             "isNew": true,
+             "legend": {
+               "alignAsTable": true,
+               "avg": false,
+               "current": false,
+               "max": false,
+               "min": false,
+               "rightSide": true,
+               "show": false,
+               "total": false,
+               "values": false
+             },
+             "lines": true,
+             "linewidth": 2,
+             "links": [],
+             "nullPointMode": "connected",
+             "percentage": false,
+             "pointradius": 5,
+             "points": false,
+             "renderer": "flot",
+             "seriesOverrides": [
+               {
+                 "alias": "/Read/",
+                 "color": "#508642",
+                 "fill": 4
+               },
+               {
+                 "alias": "/Write/",
+                 "color": "#65C5DB",
+                 "fill": 4
+               }
+             ],
+             "span": 12,
+             "stack": false,
+             "steppedLine": false,
+             "targets": [
+               {
+                 "alias": "Read - $tag_host",
+                 "dsType": "influxdb",
+                 "groupBy": [
+                   {
+                     "params": [
+                       "$interval"
+                     ],
+                     "type": "time"
+                   },
+                   {
+                     "params": [
+                       "host"
+                     ],
+                     "type": "tag"
+                   },
+                   {
+                     "params": [
+                       "null"
+                     ],
+                     "type": "fill"
+                   }
+                 ],
+                 "measurement": "influxdb_httpd",
+                 "policy": "default",
+                 "query": "SELECT non_negative_derivative(last(\"queryReq\"), 1s) FROM \"influxdb_httpd\" WHERE $timeFilter GROUP BY time($interval), \"host\" fill(null)",
+                 "refId": "A",
+                 "resultFormat": "time_series",
+                 "select": [
+                   [
+                     {
+                       "params": [
+                         "queryReq"
+                       ],
+                       "type": "field"
+                     },
+                     {
+                       "params": [],
+                       "type": "last"
+                     },
+                     {
+                       "params": [
+                         "1s"
+                       ],
+                       "type": "non_negative_derivative"
+                     }
+                   ]
+                 ],
+                 "tags": []
+               },
+               {
+                 "alias": "Write - $tag_host",
+                 "dsType": "influxdb",
+                 "groupBy": [
+                   {
+                     "params": [
+                       "$interval"
+                     ],
+                     "type": "time"
+                   },
+                   {
+                     "params": [
+                       "host"
+                     ],
+                     "type": "tag"
+                   },
+                   {
+                     "params": [
+                       "null"
+                     ],
+                     "type": "fill"
+                   }
+                 ],
+                 "measurement": "influxdb_httpd",
+                 "policy": "default",
+                 "query": "SELECT non_negative_derivative(last(\"queryReq\"), 1s) FROM \"influxdb_httpd\" WHERE $timeFilter GROUP BY time($interval), \"host\" fill(null)",
+                 "refId": "B",
+                 "resultFormat": "time_series",
+                 "select": [
+                   [
+                     {
+                       "type": "field",
+                       "params": [
+                         "writeReq"
+                       ]
+                     },
+                     {
+                       "type": "last",
+                       "params": []
+                     }
+                   ]
+                 ],
+                 "tags": []
+               }
+             ],
+             "timeFrom": null,
+             "timeShift": null,
+             "title": "HTTP Requests Per Second",
+             "tooltip": {
+               "msResolution": false,
+               "shared": true,
+               "value_type": "cumulative"
+             },
+             "type": "graph",
+             "xaxis": {
+               "show": true
+             },
+             "yaxes": [
+               {
+                 "format": "ops",
+                 "logBase": 1,
+                 "max": null,
+                 "min": null,
+                 "show": true
+               },
+               {
+                 "format": "short",
+                 "logBase": 1,
+                 "max": null,
+                 "min": null,
+                 "show": true
+               }
+             ]
+           }
+         ],
+         "title": "Row"
+       },
+       {
+         "collapse": false,
+         "editable": true,
+         "height": "250px",
+         "panels": [
+           {
+             "title": "Heap Alloc",
+             "error": false,
+             "span": 12,
+             "editable": true,
+             "type": "graph",
+             "isNew": true,
+             "id": 4,
+             "targets": [
+               {
+                 "policy": "default",
+                 "dsType": "influxdb",
+                 "resultFormat": "time_series",
+                 "tags": [],
+                 "groupBy": [
+                   {
+                     "type": "time",
+                     "params": [
+                       "$interval"
+                     ]
+                   },
+                   {
+                     "type": "fill",
+                     "params": [
+                       "null"
+                     ]
+                   }
+                 ],
+                 "select": [
+                   [
+                     {
+                       "type": "field",
+                       "params": [
+                         "heap_alloc"
+                       ]
+                     },
+                     {
+                       "type": "last",
+                       "params": []
+                     }
+                   ]
+                 ],
+                 "refId": "A",
+                 "measurement": "influxdb_memstats",
+                 "alias": "heap alloc"
+               }
+             ],
+             "datasource": null,
+             "renderer": "flot",
+             "yaxes": [
+               {
+                 "label": null,
+                 "show": true,
+                 "logBase": 1,
+                 "min": null,
+                 "max": null,
+                 "format": "bytes"
+               },
+               {
+                 "label": null,
+                 "show": true,
+                 "logBase": 1,
+                 "min": null,
+                 "max": null,
+                 "format": "short"
+               }
+             ],
+             "xaxis": {
+               "show": true
+             },
+             "grid": {
+               "threshold1": null,
+               "threshold2": null,
+               "threshold1Color": "rgba(216, 200, 27, 0.27)",
+               "threshold2Color": "rgba(234, 112, 112, 0.22)"
+             },
+             "lines": true,
+             "fill": 1,
+             "linewidth": 2,
+             "points": false,
+             "pointradius": 5,
+             "bars": false,
+             "stack": false,
+             "percentage": false,
+             "legend": {
+               "show": true,
+               "values": false,
+               "min": false,
+               "max": false,
+               "current": false,
+               "total": false,
+               "avg": false
+             },
+             "nullPointMode": "connected",
+             "steppedLine": false,
+             "tooltip": {
+               "value_type": "cumulative",
+               "shared": true,
+               "msResolution": false
+             },
+             "timeFrom": null,
+             "timeShift": null,
+             "aliasColors": {},
+             "seriesOverrides": [],
+             "links": []
+           }
+         ],
+         "title": "New row"
+       },
+       {
+         "title": "New row",
+         "height": "250px",
+         "editable": true,
+         "collapse": false,
+         "panels": [
+           {
+             "title": "Disk Usage",
+             "error": false,
+             "span": 12,
+             "editable": true,
+             "type": "graph",
+             "isNew": true,
+             "id": 5,
+             "targets": [
+               {
+                 "policy": "default",
+                 "dsType": "influxdb",
+                 "resultFormat": "time_series",
+                 "tags": [],
+                 "groupBy": [
+                   {
+                     "type": "time",
+                     "params": [
+                       "$interval"
+                     ]
+                   },
+                   {
+                     "type": "fill",
+                     "params": [
+                       "null"
+                     ]
+                   }
+                 ],
+                 "select": [
+                   [
+                     {
+                       "type": "field",
+                       "params": [
+                         "diskBytes"
+                       ]
+                     },
+                     {
+                       "type": "mean",
+                       "params": []
+                     }
+                   ]
+                 ],
+                 "refId": "A",
+                 "measurement": "influxdb_tsm1_filestore"
+               }
+             ],
+             "datasource": null,
+             "renderer": "flot",
+             "yaxes": [
+               {
+                 "label": null,
+                 "show": true,
+                 "logBase": 1,
+                 "min": null,
+                 "max": null,
+                 "format": "bytes"
+               },
+               {
+                 "label": null,
+                 "show": true,
+                 "logBase": 1,
+                 "min": null,
+                 "max": null,
+                 "format": "short"
+               }
+             ],
+             "xaxis": {
+               "show": true
+             },
+             "grid": {
+               "threshold1": null,
+               "threshold2": null,
+               "threshold1Color": "rgba(216, 200, 27, 0.27)",
+               "threshold2Color": "rgba(234, 112, 112, 0.22)"
+             },
+             "lines": true,
+             "fill": 1,
+             "linewidth": 2,
+             "points": false,
+             "pointradius": 5,
+             "bars": false,
+             "stack": false,
+             "percentage": false,
+             "legend": {
+               "show": true,
+               "values": false,
+               "min": false,
+               "max": false,
+               "current": false,
+               "total": false,
+               "avg": false
+             },
+             "nullPointMode": "connected",
+             "steppedLine": false,
+             "tooltip": {
+               "value_type": "cumulative",
+               "shared": true,
+               "msResolution": false
+             },
+             "timeFrom": null,
+             "timeShift": null,
+             "aliasColors": {},
+             "seriesOverrides": [],
+             "links": []
+           }
+         ]
+       }
+     ],
+     "time": {
+       "from": "now-5m",
+       "to": "now"
+     },
+     "timepicker": {
+       "now": true,
+       "refresh_intervals": [
+         "5s",
+         "10s",
+         "30s",
+         "1m",
+         "5m",
+         "15m",
+         "30m",
+         "1h",
+         "2h",
+         "1d"
+       ],
+       "time_options": [
+         "5m",
+         "15m",
+         "1h",
+         "6h",
+         "12h",
+         "24h",
+         "2d",
+         "7d",
+         "30d"
+       ]
+     },
+     "templating": {
+       "list": []
+     },
+     "annotations": {
+       "list": []
+     },
+     "schemaVersion": 12,
+     "version": 0,
+     "links": []
+   }
 }


### PR DESCRIPTION
Instead of using stdout metrics to read data from influx we can just count the number of requests we see and group by 1s
