### PR TITLE
feat(telegraf): enable prometheus flag

### DIFF
--- a/telegraf/manifests/deis-monitor-telegraf-daemon.yaml
+++ b/telegraf/manifests/deis-monitor-telegraf-daemon.yaml
@@ -33,6 +33,8 @@ spec:
             value: "100000"
           - name: "ENABLE_INFLUXDB_INPUT"
             value: "true"
+          - name: "ENABLE_PROMETHEUS"
+            value: "true"
           volumeMounts:
           - mountPath: /var/run/docker.sock
             name: docker-socket

--- a/telegraf/rootfs/config.toml.tpl
+++ b/telegraf/rootfs/config.toml.tpl
@@ -201,7 +201,7 @@
   {{ if .POSTGRESQL_DATABASES }} databases = [{{ .POSTGRESQL_DATABASES }}]  {{ end }}
 {{ end }}
 
-{{ if .PROMETHEUS_URLS }}
+{{ if and .PROMETHEUS_URLS .ENABLE_PROMETHEUS }}
 [[inputs.prometheus]]
   urls = [{{ .PROMETHEUS_URLS }}]
   insecure_skip_verify = {{ default true .PROMETHEUS_INSECURE_SKIP_VERIFY }}


### PR DESCRIPTION
currently at scale polling the prometheus endpoints will overwhelm the kubernetes masters.  This allows for the disabling of the prometheus data exporter.
