### PR TITLE
chore(telegraf): Update manifest to support pulling metrics from redis

### DIFF
--- a/grafana/rootfs/usr/share/grafana/dashboards/deis_health.json
+++ b/grafana/rootfs/usr/share/grafana/dashboards/deis_health.json
@@ -2,8 +2,7 @@
   "dashboard": {
     "id": null,
     "title": "Deis Health",
-    "originalTitle": "Deis Health",
-    "tags": [],
+    "tags": ["deis"],
     "style": "dark",
     "timezone": "browser",
     "editable": true,
@@ -308,7 +307,7 @@
     },
     "refresh": "5s",
     "schemaVersion": 12,
-    "version": 2,
+    "version": 0,
     "links": []
   }
 }

--- a/grafana/rootfs/usr/share/grafana/dashboards/deis_router.json
+++ b/grafana/rootfs/usr/share/grafana/dashboards/deis_router.json
@@ -2,8 +2,7 @@
   "dashboard": {
     "id": null,
     "title": "Deis Router",
-    "originalTitle": "Deis Router",
-    "tags": [],
+    "tags": ["deis"],
     "style": "dark",
     "timezone": "browser",
     "editable": true,
@@ -1049,13 +1048,6 @@
           }
         ],
         "title": "New row"
-      },
-      {
-        "collapse": false,
-        "editable": true,
-        "height": "250px",
-        "panels": [],
-        "title": "New row"
       }
     ],
     "time": {
@@ -1096,7 +1088,7 @@
     },
     "refresh": "5s",
     "schemaVersion": 12,
-    "version": 4,
+    "version": 0,
     "links": []
   }
 }

--- a/grafana/rootfs/usr/share/grafana/dashboards/influx.json
+++ b/grafana/rootfs/usr/share/grafana/dashboards/influx.json
@@ -2,8 +2,7 @@
   "dashboard": {
     "id": null,
     "title": "Influx",
-    "originalTitle": "Influx",
-    "tags": [],
+    "tags": ["deis"],
     "style": "dark",
     "timezone": "browser",
     "editable": true,

--- a/grafana/rootfs/usr/share/grafana/dashboards/kubernetes_health.json
+++ b/grafana/rootfs/usr/share/grafana/dashboards/kubernetes_health.json
@@ -1,9 +1,8 @@
 {
   "dashboard": {
-    "id": 3,
+    "id": null,
     "title": "Kubernetes Health",
-    "originalTitle": "Kubernetes Health",
-    "tags": [],
+    "tags": ["deis"],
     "style": "dark",
     "timezone": "browser",
     "editable": true,
@@ -1016,7 +1015,7 @@
     },
     "refresh": "5s",
     "schemaVersion": 12,
-    "version": 1,
+    "version": 0,
     "links": []
   }
 }

--- a/grafana/rootfs/usr/share/grafana/dashboards/redis.json
+++ b/grafana/rootfs/usr/share/grafana/dashboards/redis.json
@@ -1,7 +1,7 @@
 {
   "dashboard": {
     "id": null,
-    "title": "NSQ Health",
+    "title": "Redis",
     "tags": ["deis"],
     "style": "dark",
     "timezone": "browser",
@@ -34,7 +34,7 @@
              "thresholdLabels": false,
              "thresholdMarkers": true
            },
-           "id": 4,
+           "id": 2,
            "interval": null,
            "isNew": true,
            "links": [],
@@ -54,7 +54,6 @@
            },
            "targets": [
              {
-               "alias": "",
                "dsType": "influxdb",
                "groupBy": [
                  {
@@ -70,7 +69,7 @@
                    "type": "fill"
                  }
                ],
-               "measurement": "nsq_channel",
+               "measurement": "redis",
                "policy": "default",
                "refId": "A",
                "resultFormat": "time_series",
@@ -78,27 +77,21 @@
                  [
                    {
                      "params": [
-                       "client_count"
+                       "clients"
                      ],
                      "type": "field"
                    },
                    {
                      "params": [],
-                     "type": "mean"
+                     "type": "last"
                    }
                  ]
                ],
-               "tags": [
-                 {
-                   "key": "topic",
-                   "operator": "=",
-                   "value": "logs"
-                 }
-               ]
+               "tags": []
              }
            ],
-           "thresholds": "0",
-           "title": "Logs consumers",
+           "thresholds": "",
+           "title": "Connected Clients",
            "type": "singlestat",
            "valueFontSize": "200%",
            "valueMaps": [
@@ -110,110 +103,6 @@
            ],
            "valueName": "avg"
          },
-         {
-           "cacheTimeout": null,
-           "colorBackground": false,
-           "colorValue": false,
-           "colors": [
-             "rgba(245, 54, 54, 0.9)",
-             "rgba(237, 129, 40, 0.89)",
-             "rgba(50, 172, 45, 0.97)"
-           ],
-           "datasource": null,
-           "editable": true,
-           "error": false,
-           "format": "none",
-           "gauge": {
-             "maxValue": 100,
-             "minValue": 0,
-             "show": false,
-             "thresholdLabels": false,
-             "thresholdMarkers": true
-           },
-           "id": 5,
-           "interval": null,
-           "isNew": true,
-           "links": [],
-           "maxDataPoints": 100,
-           "nullPointMode": "connected",
-           "nullText": null,
-           "postfix": "",
-           "postfixFontSize": "50%",
-           "prefix": "",
-           "prefixFontSize": "50%",
-           "span": 6,
-           "sparkline": {
-             "fillColor": "rgba(31, 118, 189, 0.18)",
-             "full": false,
-             "lineColor": "rgb(31, 120, 193)",
-             "show": false
-           },
-           "targets": [
-             {
-               "alias": "",
-               "dsType": "influxdb",
-               "groupBy": [
-                 {
-                   "params": [
-                     "$interval"
-                   ],
-                   "type": "time"
-                 },
-                 {
-                   "params": [
-                     "null"
-                   ],
-                   "type": "fill"
-                 }
-               ],
-               "measurement": "nsq_channel",
-               "policy": "default",
-               "refId": "A",
-               "resultFormat": "time_series",
-               "select": [
-                 [
-                   {
-                     "params": [
-                       "client_count"
-                     ],
-                     "type": "field"
-                   },
-                   {
-                     "params": [],
-                     "type": "mean"
-                   }
-                 ]
-               ],
-               "tags": [
-                 {
-                   "key": "topic",
-                   "operator": "=",
-                   "value": "metrics"
-                 }
-               ]
-             }
-           ],
-           "thresholds": "0",
-           "title": "Metric consumers",
-           "type": "singlestat",
-           "valueFontSize": "200%",
-           "valueMaps": [
-             {
-               "op": "=",
-               "text": "N/A",
-               "value": "null"
-             }
-           ],
-           "valueName": "avg"
-         }
-       ],
-       "title": "New row"
-     },
-     {
-       "collapse": false,
-       "editable": true,
-       "height": "250px",
-       "panels": [
          {
            "aliasColors": {},
            "bars": false,
@@ -234,7 +123,7 @@
              "current": false,
              "max": false,
              "min": false,
-             "show": true,
+             "show": false,
              "total": false,
              "values": false
            },
@@ -247,12 +136,12 @@
            "points": false,
            "renderer": "flot",
            "seriesOverrides": [],
-           "span": 12,
+           "span": 6,
            "stack": false,
            "steppedLine": false,
            "targets": [
              {
-               "alias": "$tag_topic",
+               "alias": "Used",
                "dsType": "influxdb",
                "groupBy": [
                  {
@@ -263,18 +152,12 @@
                  },
                  {
                    "params": [
-                     "topic"
-                   ],
-                   "type": "tag"
-                 },
-                 {
-                   "params": [
                      "null"
                    ],
                    "type": "fill"
                  }
                ],
-               "measurement": "nsq_topic",
+               "measurement": "redis",
                "policy": "default",
                "refId": "A",
                "resultFormat": "time_series",
@@ -282,7 +165,7 @@
                  [
                    {
                      "params": [
-                       "depth"
+                       "used_memory"
                      ],
                      "type": "field"
                    },
@@ -297,7 +180,7 @@
            ],
            "timeFrom": null,
            "timeShift": null,
-           "title": "Topic Message Depth",
+           "title": "Memory",
            "tooltip": {
              "msResolution": true,
              "shared": true,
@@ -309,7 +192,232 @@
            },
            "yaxes": [
              {
+               "format": "bytes",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+             },
+             {
                "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+             }
+           ]
+         }
+       ],
+       "title": "New row"
+     },
+     {
+       "collapse": false,
+       "editable": true,
+       "height": "250px",
+       "panels": [
+         {
+           "aliasColors": {},
+           "bars": false,
+           "datasource": null,
+           "editable": true,
+           "error": false,
+           "fill": 1,
+           "grid": {
+             "threshold1": null,
+             "threshold1Color": "rgba(216, 200, 27, 0.27)",
+             "threshold2": null,
+             "threshold2Color": "rgba(234, 112, 112, 0.22)"
+           },
+           "id": 3,
+           "isNew": true,
+           "legend": {
+             "avg": false,
+             "current": false,
+             "max": false,
+             "min": false,
+             "show": false,
+             "total": false,
+             "values": false
+           },
+           "lines": true,
+           "linewidth": 2,
+           "links": [],
+           "nullPointMode": "connected",
+           "percentage": false,
+           "pointradius": 5,
+           "points": false,
+           "renderer": "flot",
+           "seriesOverrides": [],
+           "span": 6,
+           "stack": false,
+           "steppedLine": false,
+           "targets": [
+             {
+               "dsType": "influxdb",
+               "groupBy": [
+                 {
+                   "params": [
+                     "$interval"
+                   ],
+                   "type": "time"
+                 },
+                 {
+                   "params": [
+                     "null"
+                   ],
+                   "type": "fill"
+                 }
+               ],
+               "measurement": "container_cpu_usage_seconds_total",
+               "policy": "default",
+               "refId": "A",
+               "resultFormat": "time_series",
+               "select": [
+                 [
+                   {
+                     "params": [
+                       "counter"
+                     ],
+                     "type": "field"
+                   },
+                   {
+                     "params": [],
+                     "type": "last"
+                   },
+                   {
+                     "params": [
+                       "1s"
+                     ],
+                     "type": "non_negative_derivative"
+                   }
+                 ]
+               ],
+               "tags": []
+             }
+           ],
+           "timeFrom": null,
+           "timeShift": null,
+           "title": "CPU",
+           "tooltip": {
+             "msResolution": true,
+             "shared": true,
+             "value_type": "cumulative"
+           },
+           "type": "graph",
+           "xaxis": {
+             "show": true
+           },
+           "yaxes": [
+             {
+               "format": "s",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+             },
+             {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+             }
+           ]
+         },
+         {
+           "aliasColors": {},
+           "bars": false,
+           "datasource": null,
+           "editable": true,
+           "error": false,
+           "fill": 1,
+           "grid": {
+             "threshold1": null,
+             "threshold1Color": "rgba(216, 200, 27, 0.27)",
+             "threshold2": null,
+             "threshold2Color": "rgba(234, 112, 112, 0.22)"
+           },
+           "id": 4,
+           "interval": "1s",
+           "isNew": true,
+           "legend": {
+             "avg": false,
+             "current": false,
+             "max": false,
+             "min": false,
+             "show": false,
+             "total": false,
+             "values": false
+           },
+           "lines": true,
+           "linewidth": 2,
+           "links": [],
+           "nullPointMode": "connected",
+           "percentage": false,
+           "pointradius": 5,
+           "points": false,
+           "renderer": "flot",
+           "seriesOverrides": [],
+           "span": 6,
+           "stack": false,
+           "steppedLine": false,
+           "targets": [
+             {
+               "dsType": "influxdb",
+               "groupBy": [
+                 {
+                   "params": [
+                     "$interval"
+                   ],
+                   "type": "time"
+                 },
+                 {
+                   "params": [
+                     "null"
+                   ],
+                   "type": "fill"
+                 }
+               ],
+               "measurement": "redis",
+               "policy": "default",
+               "refId": "A",
+               "resultFormat": "time_series",
+               "select": [
+                 [
+                   {
+                     "params": [
+                       "instantaneous_ops_per_sec"
+                     ],
+                     "type": "field"
+                   },
+                   {
+                     "params": [],
+                     "type": "last"
+                   }
+                 ]
+               ],
+               "tags": []
+             }
+           ],
+           "timeFrom": null,
+           "timeShift": null,
+           "title": "Ops Per Second",
+           "tooltip": {
+             "msResolution": true,
+             "shared": true,
+             "value_type": "cumulative"
+           },
+           "type": "graph",
+           "xaxis": {
+             "show": true
+           },
+           "yaxes": [
+             {
+               "format": "ops",
                "label": null,
                "logBase": 1,
                "max": null,
@@ -328,133 +436,6 @@
          }
        ],
        "title": "Row"
-     },
-     {
-       "collapse": false,
-       "editable": true,
-       "height": "250px",
-       "panels": [
-         {
-           "title": "Messages Per Second / Topic",
-           "error": false,
-           "span": 12,
-           "editable": true,
-           "type": "graph",
-           "isNew": true,
-           "id": 6,
-           "targets": [
-             {
-               "policy": "default",
-               "dsType": "influxdb",
-               "resultFormat": "time_series",
-               "tags": [],
-               "groupBy": [
-                 {
-                   "type": "time",
-                   "params": [
-                     "$interval"
-                   ]
-                 },
-                 {
-                   "type": "tag",
-                   "params": [
-                     "topic"
-                   ]
-                 },
-                 {
-                   "type": "fill",
-                   "params": [
-                     "null"
-                   ]
-                 }
-               ],
-               "select": [
-                 [
-                   {
-                     "type": "field",
-                     "params": [
-                       "message_count"
-                     ]
-                   },
-                   {
-                     "type": "last",
-                     "params": []
-                   },
-                   {
-                     "type": "non_negative_derivative",
-                     "params": [
-                       "1s"
-                     ]
-                   }
-                 ]
-               ],
-               "refId": "A",
-               "measurement": "nsq_topic",
-               "alias": "$tag_topic"
-             }
-           ],
-           "datasource": null,
-           "renderer": "flot",
-           "yaxes": [
-             {
-               "label": null,
-               "show": true,
-               "logBase": 1,
-               "min": null,
-               "max": null,
-               "format": "short"
-             },
-             {
-               "label": null,
-               "show": true,
-               "logBase": 1,
-               "min": null,
-               "max": null,
-               "format": "short"
-             }
-           ],
-           "xaxis": {
-             "show": true
-           },
-           "grid": {
-             "threshold1": null,
-             "threshold2": null,
-             "threshold1Color": "rgba(216, 200, 27, 0.27)",
-             "threshold2Color": "rgba(234, 112, 112, 0.22)"
-           },
-           "lines": true,
-           "fill": 1,
-           "linewidth": 2,
-           "points": false,
-           "pointradius": 5,
-           "bars": false,
-           "stack": false,
-           "percentage": false,
-           "legend": {
-             "show": true,
-             "values": false,
-             "min": false,
-             "max": false,
-             "current": false,
-             "total": false,
-             "avg": false
-           },
-           "nullPointMode": "connected",
-           "steppedLine": false,
-           "tooltip": {
-             "value_type": "cumulative",
-             "shared": true,
-             "msResolution": true
-           },
-           "timeFrom": null,
-           "timeShift": null,
-           "aliasColors": {},
-           "seriesOverrides": [],
-           "interval": "1s",
-           "links": []
-         }
-       ],
-       "title": "New row"
      }
     ],
     "time": {
@@ -492,9 +473,8 @@
     "annotations": {
      "list": []
     },
-    "refresh": "5s",
     "schemaVersion": 12,
     "version": 0,
     "links": []
-   }
- }
+  }
+}

--- a/grafana/rootfs/usr/share/grafana/start-grafana
+++ b/grafana/rootfs/usr/share/grafana/start-grafana
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Some of the contents of this file came from here - https://github.com/kubernetes/heapster/blob/master/grafana/run.sh
+# Some of the contents of this file came from here - https://github.com/kubernetes/heapster/blob/ed5baadf04ea9f8e48fc7d44dad63a63af34ff9b/grafana/run.sh
 HEADER_CONTENT_TYPE="Content-Type: application/json"
 HEADER_ACCEPT="Accept: application/json"
 

--- a/telegraf/manifests/deis-monitor-telegraf-daemon.yaml
+++ b/telegraf/manifests/deis-monitor-telegraf-daemon.yaml
@@ -41,6 +41,13 @@ spec:
             value: "metrics"
           - name: "NSQ_ENDPOINTS"
             value: http://$(DEIS_NSQD_SERVICE_HOST):$(DEIS_NSQD_SERVICE_PORT_HTTP)
+          - name: DEIS_LOGGER_REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: logger-redis-creds
+                key: password
+          - name: "REDIS_SERVERS"
+            value: tcp://:$(DEIS_LOGGER_REDIS_PASSWORD)@$(DEIS_LOGGER_REDIS_SERVICE_HOST):$(DEIS_LOGGER_REDIS_SERVICE_PORT)
           volumeMounts:
           - mountPath: /var/run/docker.sock
             name: docker-socket
@@ -66,3 +73,6 @@ spec:
       - name: varrunutmpro
         hostPath:
           path: /var/run/utmp
+      - name: logger-redis-creds
+        secret:
+          secretName: logger-redis-creds

--- a/telegraf/rootfs/config.toml.tpl
+++ b/telegraf/rootfs/config.toml.tpl
@@ -13,8 +13,8 @@
   interval = {{ default "10s" .AGENT_INTERVAL | quote }}
   round_interval = {{ default true .AGENT_ROUND_INTERVAL }}
   metric_buffer_limit = {{ default "10000" .AGENT_BUFFER_LIMIT }}
-  collection_jitter = {{ default "0s" .AGENT_COLLECTION_JITTER | quote }}
-  flush_interval = {{ default "10s" .AGENT_FLUSH_INTERVAL | quote }}
+  collection_jitter = {{ default "1s" .AGENT_COLLECTION_JITTER | quote }}
+  flush_interval = {{ default "1s" .AGENT_FLUSH_INTERVAL | quote }}
   flush_jitter = {{ default "0s" .AGENT_FLUSH_JITTER | quote }}
   debug = {{ default false .AGENT_DEBUG }}
   quiet = {{ default false .AGENT_QUIET }}
@@ -192,6 +192,7 @@
 {{ if .NSQ_ENDPOINTS }}
 [[inputs.nsq]]
   endpoints = [{{ .NSQ_ENDPOINTS | quote }}]
+  interval = {{ default "1s" .AGENT_INTERVAL | quote }}
 {{ end }}
 
 {{ if .POSTGRESQL_ADDRESS }}
@@ -223,7 +224,7 @@
 
 {{ if .REDIS_SERVERS }}
 [[inputs.redis]]
-  servers = [{{ .REDIS_SERVERS }}]
+  servers = [{{ .REDIS_SERVERS | quote }}]
 {{ end }}
 
 {{ if .RETHINKDB_SERVERS }}


### PR DESCRIPTION
This PR adds the ability to monitor our redis instance.
Depends on - https://github.com/deis/charts/pull/293

It also updates all of the dashboards to remove some unnecessary fields in the json and clean up their reported versions. 

Manual Testing:
1. Deploy deis using the following chart pr - https://github.com/deis/charts/pull/293
2. run `make build push upgrade` within the telegraf directory
3. run `make build push upgrade` within the grafana directory
4. goto `grafana.mydomain.com` and login admin/admin
5. Make sure there is a redis dashboard available
6. Make sure the charts are being populated with information.
