### PR TITLE
fix(telegraf): Create nsq topic at startup

### DIFF
--- a/telegraf/rootfs/start-telegraf
+++ b/telegraf/rootfs/start-telegraf
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -e
 
+if [ -n $DEIS_NSQD_SERVICE_HOST ]; then
+  echo "Creating topic with URL: http://$DEIS_NSQD_SERVICE_HOST:$DEIS_NSQD_SERVICE_PORT/topic/create?topic=$NSQ_CONSUMER_TOPIC"
+  curl -s -X POST http://$DEIS_NSQD_SERVICE_HOST:$DEIS_NSQD_SERVICE_PORT/topic/create?topic=$NSQ_CONSUMER_TOPIC
+fi
+
 export PROMETHEUS_BEARER_TOKEN=/var/run/secrets/kubernetes.io/serviceaccount/token
 if [ -f $PROMETHEUS_BEARER_TOKEN ]; then
     export TOKEN=$(cat $PROMETHEUS_BEARER_TOKEN)


### PR DESCRIPTION
This should fix the start up issue where telegraf starts and fluentd has
yet to create the metrics topic
