### PR TITLE
chore(grafana): Update dashboards with new graphs

### DIFF
--- a/grafana/rootfs/usr/share/grafana/dashboards/deis_health.json
+++ b/grafana/rootfs/usr/share/grafana/dashboards/deis_health.json
@@ -3,6 +3,7 @@
     "id": null,
     "title": "Deis Health",
     "tags": ["deis"],
+    "originalTitle": "Deis Health",
     "style": "dark",
     "timezone": "browser",
     "editable": true,
@@ -81,14 +82,14 @@
                 "select": [
                   [
                     {
-                      "type": "field",
                       "params": [
                         "gauge"
-                      ]
+                      ],
+                      "type": "field"
                     },
                     {
-                      "type": "last",
-                      "params": []
+                      "params": [],
+                      "type": "last"
                     }
                   ]
                 ],
@@ -103,7 +104,7 @@
             ],
             "timeFrom": null,
             "timeShift": null,
-            "title": "Memory Usage",
+            "title": "Memory",
             "tooltip": {
               "msResolution": true,
               "shared": true,
@@ -154,7 +155,7 @@
               "threshold2Color": "rgba(234, 112, 112, 0.22)"
             },
             "id": 2,
-            "interval": "",
+            "interval": "1s",
             "isNew": true,
             "legend": {
               "avg": false,
@@ -180,7 +181,7 @@
             "steppedLine": false,
             "targets": [
               {
-                "alias": "$tag_kubernetes_pod_name",
+                "alias": "$tag_kubernetes_container_name",
                 "dsType": "influxdb",
                 "groupBy": [
                   {
@@ -191,7 +192,7 @@
                   },
                   {
                     "params": [
-                      "kubernetes_pod_name"
+                      "kubernetes_container_name"
                     ],
                     "type": "tag"
                   },
@@ -220,7 +221,7 @@
                     },
                     {
                       "params": [
-                        "10s"
+                        "1s"
                       ],
                       "type": "non_negative_derivative"
                     }
@@ -237,7 +238,7 @@
             ],
             "timeFrom": null,
             "timeShift": null,
-            "title": "CPU Usage",
+            "title": "CPU",
             "tooltip": {
               "msResolution": false,
               "shared": true,

--- a/grafana/rootfs/usr/share/grafana/dashboards/deis_router.json
+++ b/grafana/rootfs/usr/share/grafana/dashboards/deis_router.json
@@ -2,6 +2,7 @@
   "dashboard": {
     "id": null,
     "title": "Deis Router",
+    "originalTitle": "Deis Router",
     "tags": ["deis"],
     "style": "dark",
     "timezone": "browser",
@@ -9,6 +10,243 @@
     "hideControls": false,
     "sharedCrosshair": false,
     "rows": [
+      {
+        "collapse": false,
+        "editable": true,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "id": 3,
+            "interval": "1s",
+            "isNew": true,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 3,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+              {
+                "alias": "user",
+                "color": "#CCA300",
+                "fill": 3
+              },
+              {
+                "alias": "/cpu/",
+                "fill": 3
+              },
+              {
+                "alias": "system",
+                "color": "#890F02",
+                "fill": 3
+              }
+            ],
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "alias": "",
+                "dsType": "influxdb",
+                "groupBy": [
+                  {
+                    "params": [
+                      "$interval"
+                    ],
+                    "type": "time"
+                  },
+                  {
+                    "params": [
+                      "null"
+                    ],
+                    "type": "fill"
+                  }
+                ],
+                "measurement": "container_cpu_usage_seconds_total",
+                "policy": "default",
+                "refId": "B",
+                "resultFormat": "time_series",
+                "select": [
+                  [
+                    {
+                      "params": [
+                        "counter"
+                      ],
+                      "type": "field"
+                    },
+                    {
+                      "params": [],
+                      "type": "last"
+                    },
+                    {
+                      "params": [
+                        "1s"
+                      ],
+                      "type": "non_negative_derivative"
+                    }
+                  ]
+                ],
+                "tags": [
+                  {
+                    "key": "kubernetes_container_name",
+                    "operator": "=",
+                    "value": "deis-router"
+                  }
+                ]
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "CPU",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "show": true
+            },
+            "yaxes": [
+              {
+                "format": "s",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "title": "Memory",
+            "error": false,
+            "span": 6,
+            "editable": true,
+            "type": "singlestat",
+            "isNew": true,
+            "id": 10,
+            "targets": [
+              {
+                "policy": "default",
+                "dsType": "influxdb",
+                "resultFormat": "time_series",
+                "tags": [
+                  {
+                    "key": "kubernetes_container_name",
+                    "operator": "=",
+                    "value": "deis-router"
+                  }
+                ],
+                "groupBy": [
+                  {
+                    "type": "time",
+                    "params": [
+                      "$interval"
+                    ]
+                  },
+                  {
+                    "type": "fill",
+                    "params": [
+                      "null"
+                    ]
+                  }
+                ],
+                "select": [
+                  [
+                    {
+                      "type": "field",
+                      "params": [
+                        "gauge"
+                      ]
+                    },
+                    {
+                      "type": "last",
+                      "params": []
+                    }
+                  ]
+                ],
+                "refId": "A",
+                "measurement": "container_memory_usage_bytes"
+              }
+            ],
+            "links": [],
+            "datasource": null,
+            "maxDataPoints": 100,
+            "interval": null,
+            "cacheTimeout": null,
+            "format": "bytes",
+            "prefix": "",
+            "postfix": "",
+            "nullText": null,
+            "valueMaps": [
+              {
+                "value": "null",
+                "op": "=",
+                "text": "N/A"
+              }
+            ],
+            "nullPointMode": "connected",
+            "valueName": "current",
+            "prefixFontSize": "50%",
+            "valueFontSize": "200%",
+            "postfixFontSize": "50%",
+            "thresholds": "",
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+              "rgba(245, 54, 54, 0.9)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(50, 172, 45, 0.97)"
+            ],
+            "sparkline": {
+              "show": false,
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "fillColor": "rgba(31, 118, 189, 0.18)"
+            },
+            "gauge": {
+              "show": false,
+              "minValue": 0,
+              "maxValue": 100,
+              "thresholdMarkers": true,
+              "thresholdLabels": false
+            }
+          }
+        ],
+        "title": "New row"
+      },
       {
         "collapse": false,
         "editable": true,
@@ -402,7 +640,7 @@
                 "fill": 0
               }
             ],
-            "span": 12,
+            "span": 6,
             "stack": false,
             "steppedLine": false,
             "targets": [
@@ -532,15 +770,7 @@
                 "show": false
               }
             ]
-          }
-        ],
-        "title": "New row"
-      },
-      {
-        "collapse": false,
-        "editable": true,
-        "height": "250px",
-        "panels": [
+          },
           {
             "aliasColors": {},
             "bars": false,
@@ -791,245 +1021,6 @@
             "yaxes": [
               {
                 "format": "short",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": null,
-                "show": true
-              },
-              {
-                "format": "short",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": null,
-                "show": true
-              }
-            ]
-          },
-          {
-            "aliasColors": {},
-            "bars": false,
-            "datasource": null,
-            "editable": true,
-            "error": false,
-            "fill": 1,
-            "grid": {
-              "threshold1": null,
-              "threshold1Color": "rgba(216, 200, 27, 0.27)",
-              "threshold2": null,
-              "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "id": 3,
-            "interval": "30s",
-            "isNew": true,
-            "legend": {
-              "avg": false,
-              "current": false,
-              "max": false,
-              "min": false,
-              "show": true,
-              "total": false,
-              "values": false
-            },
-            "lines": true,
-            "linewidth": 3,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-              {
-                "alias": "user",
-                "color": "#CCA300",
-                "fill": 3
-              },
-              {
-                "alias": "/cpu/",
-                "fill": 3
-              },
-              {
-                "alias": "system",
-                "color": "#890F02",
-                "fill": 3
-              }
-            ],
-            "span": 6,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-              {
-                "alias": "user",
-                "dsType": "influxdb",
-                "groupBy": [
-                  {
-                    "params": [
-                      "$interval"
-                    ],
-                    "type": "time"
-                  },
-                  {
-                    "params": [
-                      "null"
-                    ],
-                    "type": "fill"
-                  }
-                ],
-                "measurement": "container_cpu_user_seconds_total",
-                "policy": "default",
-                "refId": "A",
-                "resultFormat": "time_series",
-                "select": [
-                  [
-                    {
-                      "params": [
-                        "counter"
-                      ],
-                      "type": "field"
-                    },
-                    {
-                      "params": [],
-                      "type": "last"
-                    },
-                    {
-                      "params": [
-                        "10s"
-                      ],
-                      "type": "derivative"
-                    }
-                  ]
-                ],
-                "tags": [
-                  {
-                    "key": "io_kubernetes_container_name",
-                    "operator": "=",
-                    "value": "deis-router"
-                  }
-                ]
-              },
-              {
-                "alias": "$tag_cpu",
-                "dsType": "influxdb",
-                "groupBy": [
-                  {
-                    "params": [
-                      "$interval"
-                    ],
-                    "type": "time"
-                  },
-                  {
-                    "params": [
-                      "cpu"
-                    ],
-                    "type": "tag"
-                  },
-                  {
-                    "params": [
-                      "null"
-                    ],
-                    "type": "fill"
-                  }
-                ],
-                "measurement": "container_cpu_usage_seconds_total",
-                "policy": "default",
-                "refId": "B",
-                "resultFormat": "time_series",
-                "select": [
-                  [
-                    {
-                      "params": [
-                        "counter"
-                      ],
-                      "type": "field"
-                    },
-                    {
-                      "params": [],
-                      "type": "last"
-                    },
-                    {
-                      "params": [
-                        "10s"
-                      ],
-                      "type": "derivative"
-                    }
-                  ]
-                ],
-                "tags": [
-                  {
-                    "key": "io_kubernetes_container_name",
-                    "operator": "=",
-                    "value": "deis-router"
-                  }
-                ]
-              },
-              {
-                "alias": "system",
-                "dsType": "influxdb",
-                "groupBy": [
-                  {
-                    "params": [
-                      "$interval"
-                    ],
-                    "type": "time"
-                  },
-                  {
-                    "params": [
-                      "null"
-                    ],
-                    "type": "fill"
-                  }
-                ],
-                "hide": false,
-                "measurement": "container_cpu_system_seconds_total",
-                "policy": "default",
-                "refId": "C",
-                "resultFormat": "time_series",
-                "select": [
-                  [
-                    {
-                      "params": [
-                        "value"
-                      ],
-                      "type": "field"
-                    },
-                    {
-                      "params": [],
-                      "type": "last"
-                    },
-                    {
-                      "params": [
-                        "10s"
-                      ],
-                      "type": "derivative"
-                    }
-                  ]
-                ],
-                "tags": [
-                  {
-                    "key": "io_kubernetes_container_name",
-                    "operator": "=",
-                    "value": "deis-router"
-                  }
-                ]
-              }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "CPU Usage",
-            "tooltip": {
-              "msResolution": false,
-              "shared": true,
-              "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-              "show": true
-            },
-            "yaxes": [
-              {
-                "format": "s",
                 "label": null,
                 "logBase": 1,
                 "max": null,

--- a/grafana/rootfs/usr/share/grafana/dashboards/influx.json
+++ b/grafana/rootfs/usr/share/grafana/dashboards/influx.json
@@ -3,6 +3,7 @@
     "id": null,
     "title": "Influx",
     "tags": ["deis"],
+    "originalTitle": "Influx",
     "style": "dark",
     "timezone": "browser",
     "editable": true,
@@ -12,7 +13,7 @@
       {
         "collapse": false,
         "editable": true,
-        "height": "250px",
+        "height": "100px",
         "panels": [
           {
             "cacheTimeout": null,
@@ -200,6 +201,198 @@
       {
         "collapse": false,
         "editable": true,
+        "height": "100px",
+        "panels": [
+          {
+            "title": "Memory",
+            "error": false,
+            "span": 6,
+            "editable": true,
+            "type": "singlestat",
+            "isNew": true,
+            "id": 4,
+            "targets": [
+              {
+                "policy": "default",
+                "dsType": "influxdb",
+                "resultFormat": "time_series",
+                "tags": [
+                  {
+                    "key": "kubernetes_container_name",
+                    "operator": "=",
+                    "value": "deis-monitor-influxdb"
+                  }
+                ],
+                "groupBy": [
+                  {
+                    "type": "time",
+                    "params": [
+                      "$interval"
+                    ]
+                  },
+                  {
+                    "type": "fill",
+                    "params": [
+                      "null"
+                    ]
+                  }
+                ],
+                "select": [
+                  [
+                    {
+                      "type": "field",
+                      "params": [
+                        "gauge"
+                      ]
+                    },
+                    {
+                      "type": "last",
+                      "params": []
+                    }
+                  ]
+                ],
+                "refId": "A",
+                "measurement": "container_memory_usage_bytes"
+              }
+            ],
+            "links": [],
+            "datasource": null,
+            "maxDataPoints": 100,
+            "interval": null,
+            "cacheTimeout": null,
+            "format": "bytes",
+            "prefix": "",
+            "postfix": "",
+            "nullText": null,
+            "valueMaps": [
+              {
+                "value": "null",
+                "op": "=",
+                "text": "N/A"
+              }
+            ],
+            "nullPointMode": "connected",
+            "valueName": "current",
+            "prefixFontSize": "50%",
+            "valueFontSize": "200%",
+            "postfixFontSize": "50%",
+            "thresholds": "",
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+              "rgba(245, 54, 54, 0.9)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(50, 172, 45, 0.97)"
+            ],
+            "sparkline": {
+              "show": true,
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "fillColor": "rgba(31, 118, 189, 0.18)"
+            },
+            "gauge": {
+              "show": false,
+              "minValue": 0,
+              "maxValue": 100,
+              "thresholdMarkers": true,
+              "thresholdLabels": false
+            }
+          },
+          {
+            "title": "Database Size",
+            "error": false,
+            "span": 6,
+            "editable": true,
+            "type": "singlestat",
+            "isNew": true,
+            "id": 5,
+            "targets": [
+              {
+                "policy": "default",
+                "dsType": "influxdb",
+                "resultFormat": "time_series",
+                "tags": [],
+                "groupBy": [
+                  {
+                    "type": "time",
+                    "params": [
+                      "$interval"
+                    ]
+                  },
+                  {
+                    "type": "fill",
+                    "params": [
+                      "null"
+                    ]
+                  }
+                ],
+                "select": [
+                  [
+                    {
+                      "type": "field",
+                      "params": [
+                        "diskBytes"
+                      ]
+                    },
+                    {
+                      "type": "last",
+                      "params": []
+                    }
+                  ]
+                ],
+                "refId": "A",
+                "measurement": "influxdb_shard"
+              }
+            ],
+            "links": [],
+            "datasource": null,
+            "maxDataPoints": 100,
+            "interval": null,
+            "cacheTimeout": null,
+            "format": "bytes",
+            "prefix": "",
+            "postfix": "",
+            "nullText": null,
+            "valueMaps": [
+              {
+                "value": "null",
+                "op": "=",
+                "text": "N/A"
+              }
+            ],
+            "nullPointMode": "connected",
+            "valueName": "current",
+            "prefixFontSize": "50%",
+            "valueFontSize": "200%",
+            "postfixFontSize": "50%",
+            "thresholds": "",
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+              "rgba(245, 54, 54, 0.9)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(50, 172, 45, 0.97)"
+            ],
+            "sparkline": {
+              "show": true,
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "fillColor": "rgba(31, 118, 189, 0.18)"
+            },
+            "gauge": {
+              "show": false,
+              "minValue": 0,
+              "maxValue": 100,
+              "thresholdMarkers": true,
+              "thresholdLabels": false
+            }
+          }
+        ],
+        "title": "New row"
+      },
+      {
+        "collapse": false,
+        "editable": true,
         "height": "250px",
         "panels": [
           {
@@ -245,7 +438,7 @@
               },
               {
                 "alias": "/Write/",
-                "color": "#65C5DB",
+                "color": "#E0752D",
                 "fill": 4
               }
             ],
@@ -284,20 +477,20 @@
                 "select": [
                   [
                     {
-                      "type": "field",
                       "params": [
                         "queryReq"
-                      ]
+                      ],
+                      "type": "field"
                     },
                     {
-                      "type": "last",
-                      "params": []
+                      "params": [],
+                      "type": "last"
                     },
                     {
-                      "type": "non_negative_derivative",
                       "params": [
                         "1s"
-                      ]
+                      ],
+                      "type": "non_negative_derivative"
                     }
                   ]
                 ],
@@ -334,20 +527,20 @@
                 "select": [
                   [
                     {
-                      "type": "field",
                       "params": [
                         "writeReq"
-                      ]
+                      ],
+                      "type": "field"
                     },
                     {
-                      "type": "last",
-                      "params": []
+                      "params": [],
+                      "type": "last"
                     },
                     {
-                      "type": "non_negative_derivative",
                       "params": [
                         "10s"
-                      ]
+                      ],
+                      "type": "non_negative_derivative"
                     }
                   ]
                 ],
@@ -385,233 +578,6 @@
           }
         ],
         "title": "Row"
-      },
-      {
-        "collapse": false,
-        "editable": true,
-        "height": "250px",
-        "panels": [
-          {
-            "aliasColors": {},
-            "bars": false,
-            "datasource": null,
-            "editable": true,
-            "error": false,
-            "fill": 1,
-            "grid": {
-              "threshold1": null,
-              "threshold1Color": "rgba(216, 200, 27, 0.27)",
-              "threshold2": null,
-              "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "id": 4,
-            "isNew": true,
-            "legend": {
-              "avg": false,
-              "current": false,
-              "max": false,
-              "min": false,
-              "show": true,
-              "total": false,
-              "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 12,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-              {
-                "alias": "heap alloc",
-                "dsType": "influxdb",
-                "groupBy": [
-                  {
-                    "params": [
-                      "$interval"
-                    ],
-                    "type": "time"
-                  },
-                  {
-                    "params": [
-                      "null"
-                    ],
-                    "type": "fill"
-                  }
-                ],
-                "measurement": "influxdb_memstats",
-                "policy": "default",
-                "refId": "A",
-                "resultFormat": "time_series",
-                "select": [
-                  [
-                    {
-                      "params": [
-                        "heap_alloc"
-                      ],
-                      "type": "field"
-                    },
-                    {
-                      "params": [],
-                      "type": "last"
-                    }
-                  ]
-                ],
-                "tags": []
-              }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Heap Alloc",
-            "tooltip": {
-              "msResolution": false,
-              "shared": true,
-              "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-              "show": true
-            },
-            "yaxes": [
-              {
-                "format": "bytes",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": null,
-                "show": true
-              },
-              {
-                "format": "short",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": null,
-                "show": true
-              }
-            ]
-          }
-        ],
-        "title": "New row"
-      },
-      {
-        "collapse": false,
-        "editable": true,
-        "height": "250px",
-        "panels": [
-          {
-            "aliasColors": {},
-            "bars": false,
-            "datasource": null,
-            "editable": true,
-            "error": false,
-            "fill": 1,
-            "grid": {
-              "threshold1": null,
-              "threshold1Color": "rgba(216, 200, 27, 0.27)",
-              "threshold2": null,
-              "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "id": 5,
-            "isNew": true,
-            "legend": {
-              "avg": false,
-              "current": false,
-              "max": false,
-              "min": false,
-              "show": true,
-              "total": false,
-              "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "span": 12,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-              {
-                "dsType": "influxdb",
-                "groupBy": [
-                  {
-                    "params": [
-                      "$interval"
-                    ],
-                    "type": "time"
-                  },
-                  {
-                    "params": [
-                      "null"
-                    ],
-                    "type": "fill"
-                  }
-                ],
-                "measurement": "influxdb_tsm1_filestore",
-                "policy": "default",
-                "refId": "A",
-                "resultFormat": "time_series",
-                "select": [
-                  [
-                    {
-                      "params": [
-                        "diskBytes"
-                      ],
-                      "type": "field"
-                    },
-                    {
-                      "params": [],
-                      "type": "mean"
-                    }
-                  ]
-                ],
-                "tags": []
-              }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Disk Usage",
-            "tooltip": {
-              "msResolution": false,
-              "shared": true,
-              "value_type": "cumulative"
-            },
-            "type": "graph",
-            "xaxis": {
-              "show": true
-            },
-            "yaxes": [
-              {
-                "format": "bytes",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": null,
-                "show": true
-              },
-              {
-                "format": "short",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": null,
-                "show": true
-              }
-            ]
-          }
-        ],
-        "title": "New row"
       }
     ],
     "time": {
@@ -651,7 +617,7 @@
       "list": []
     },
     "schemaVersion": 12,
-    "version": 0,
+    "version": 1,
     "links": []
   }
 }

--- a/grafana/rootfs/usr/share/grafana/dashboards/kubernetes_health.json
+++ b/grafana/rootfs/usr/share/grafana/dashboards/kubernetes_health.json
@@ -3,6 +3,7 @@
     "id": null,
     "title": "Kubernetes Health",
     "tags": ["deis"],
+    "originalTitle": "Kubernetes Health",
     "style": "dark",
     "timezone": "browser",
     "editable": true,
@@ -10,10 +11,100 @@
     "sharedCrosshair": false,
     "rows": [
       {
-        "collapse": false,
+        "title": "New row",
+        "height": "100px",
         "editable": true,
-        "height": "250px",
+        "collapse": false,
         "panels": [
+          {
+            "title": "Pod Memory Usage",
+            "error": false,
+            "span": 6,
+            "editable": true,
+            "type": "singlestat",
+            "isNew": true,
+            "id": 11,
+            "targets": [
+              {
+                "policy": "default",
+                "dsType": "influxdb",
+                "resultFormat": "time_series",
+                "tags": [],
+                "groupBy": [
+                  {
+                    "type": "time",
+                    "params": [
+                      "$interval"
+                    ]
+                  },
+                  {
+                    "type": "fill",
+                    "params": [
+                      "null"
+                    ]
+                  }
+                ],
+                "select": [
+                  [
+                    {
+                      "type": "field",
+                      "params": [
+                        "gauge"
+                      ]
+                    },
+                    {
+                      "type": "last",
+                      "params": []
+                    }
+                  ]
+                ],
+                "refId": "A",
+                "measurement": "container_memory_usage_bytes"
+              }
+            ],
+            "links": [],
+            "datasource": null,
+            "maxDataPoints": 100,
+            "interval": null,
+            "cacheTimeout": null,
+            "format": "bytes",
+            "prefix": "",
+            "postfix": "",
+            "nullText": null,
+            "valueMaps": [
+              {
+                "value": "null",
+                "op": "=",
+                "text": "N/A"
+              }
+            ],
+            "nullPointMode": "connected",
+            "valueName": "current",
+            "prefixFontSize": "50%",
+            "valueFontSize": "200%",
+            "postfixFontSize": "50%",
+            "thresholds": "",
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+              "rgba(245, 54, 54, 0.9)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(50, 172, 45, 0.97)"
+            ],
+            "sparkline": {
+              "show": true,
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "fillColor": "rgba(31, 118, 189, 0.18)"
+            },
+            "gauge": {
+              "show": false,
+              "minValue": 0,
+              "maxValue": 100,
+              "thresholdMarkers": true,
+              "thresholdLabels": false
+            }
+          },
           {
             "cacheTimeout": null,
             "colorBackground": false,
@@ -102,7 +193,14 @@
               }
             ],
             "valueName": "avg"
-          },
+          }
+        ]
+      },
+      {
+        "collapse": false,
+        "editable": true,
+        "height": "250px",
+        "panels": [
           {
             "aliasColors": {},
             "bars": false,
@@ -285,15 +383,7 @@
                 "show": true
               }
             ]
-          }
-        ],
-        "title": "New row"
-      },
-      {
-        "collapse": false,
-        "editable": true,
-        "height": "250px",
-        "panels": [
+          },
           {
             "aliasColors": {},
             "bars": false,
@@ -478,7 +568,15 @@
                 "show": true
               }
             ]
-          },
+          }
+        ],
+        "title": "New row"
+      },
+      {
+        "collapse": false,
+        "editable": true,
+        "height": "250px",
+        "panels": [
           {
             "aliasColors": {},
             "bars": false,
@@ -582,6 +680,189 @@
             "yaxes": [
               {
                 "format": "ops",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "id": 7,
+            "isNew": true,
+            "legend": {
+              "alignAsTable": true,
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "rightSide": true,
+              "show": false,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "alias": "Average",
+                "dsType": "influxdb",
+                "groupBy": [
+                  {
+                    "params": [
+                      "$interval"
+                    ],
+                    "type": "time"
+                  },
+                  {
+                    "params": [
+                      "null"
+                    ],
+                    "type": "fill"
+                  }
+                ],
+                "measurement": "kubelet_pod_worker_latency_microseconds",
+                "policy": "default",
+                "query": "SELECT last(\"0.5\") FROM \"kubelet_pod_worker_latency_microseconds\" WHERE $timeFilter GROUP BY time($interval), \"host\" fill(null)",
+                "refId": "A",
+                "resultFormat": "time_series",
+                "select": [
+                  [
+                    {
+                      "params": [
+                        "0.5"
+                      ],
+                      "type": "field"
+                    },
+                    {
+                      "params": [],
+                      "type": "last"
+                    }
+                  ]
+                ],
+                "tags": []
+              },
+              {
+                "alias": "90th",
+                "dsType": "influxdb",
+                "groupBy": [
+                  {
+                    "params": [
+                      "$interval"
+                    ],
+                    "type": "time"
+                  },
+                  {
+                    "params": [
+                      "null"
+                    ],
+                    "type": "fill"
+                  }
+                ],
+                "measurement": "kubelet_pod_worker_latency_microseconds",
+                "policy": "default",
+                "query": "SELECT last(\"0.9\") FROM \"kubelet_pod_worker_latency_microseconds\" WHERE $timeFilter GROUP BY time($interval), \"host\" fill(null)",
+                "refId": "B",
+                "resultFormat": "time_series",
+                "select": [
+                  [
+                    {
+                      "params": [
+                        "0.9"
+                      ],
+                      "type": "field"
+                    },
+                    {
+                      "params": [],
+                      "type": "last"
+                    }
+                  ]
+                ],
+                "tags": []
+              },
+              {
+                "alias": "99th",
+                "dsType": "influxdb",
+                "groupBy": [
+                  {
+                    "params": [
+                      "$interval"
+                    ],
+                    "type": "time"
+                  },
+                  {
+                    "params": [
+                      "null"
+                    ],
+                    "type": "fill"
+                  }
+                ],
+                "measurement": "kubelet_pod_worker_latency_microseconds",
+                "policy": "default",
+                "query": "SELECT last(\"0.99\") FROM \"kubelet_pod_worker_latency_microseconds\" WHERE $timeFilter GROUP BY time($interval), \"host\" fill(null)",
+                "refId": "C",
+                "resultFormat": "time_series",
+                "select": [
+                  [
+                    {
+                      "params": [
+                        "0.99"
+                      ],
+                      "type": "field"
+                    },
+                    {
+                      "params": [],
+                      "type": "last"
+                    }
+                  ]
+                ],
+                "tags": []
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Kubelet Pod Worker Latency",
+            "tooltip": {
+              "msResolution": true,
+              "shared": true,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "show": true
+            },
+            "yaxes": [
+              {
+                "format": "µs",
                 "logBase": 1,
                 "max": null,
                 "min": null,
@@ -790,187 +1071,115 @@
             ]
           },
           {
-            "aliasColors": {},
-            "bars": false,
-            "datasource": null,
-            "editable": true,
+            "title": "API Resource API Latency",
             "error": false,
-            "fill": 1,
-            "grid": {
-              "threshold1": null,
-              "threshold1Color": "rgba(216, 200, 27, 0.27)",
-              "threshold2": null,
-              "threshold2Color": "rgba(234, 112, 112, 0.22)"
-            },
-            "id": 7,
-            "isNew": true,
-            "legend": {
-              "alignAsTable": true,
-              "avg": false,
-              "current": false,
-              "max": false,
-              "min": false,
-              "rightSide": true,
-              "show": false,
-              "total": false,
-              "values": false
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "connected",
-            "percentage": false,
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
             "span": 6,
-            "stack": false,
-            "steppedLine": false,
+            "editable": true,
+            "type": "graph",
+            "isNew": true,
+            "id": 12,
             "targets": [
               {
-                "alias": "Average",
+                "policy": "default",
                 "dsType": "influxdb",
+                "resultFormat": "time_series",
+                "tags": [],
                 "groupBy": [
                   {
+                    "type": "time",
                     "params": [
                       "$interval"
-                    ],
-                    "type": "time"
+                    ]
                   },
                   {
+                    "type": "tag",
+                    "params": [
+                      "resource"
+                    ]
+                  },
+                  {
+                    "type": "fill",
                     "params": [
                       "null"
-                    ],
-                    "type": "fill"
+                    ]
                   }
                 ],
-                "measurement": "kubelet_pod_worker_latency_microseconds",
-                "policy": "default",
-                "query": "SELECT last(\"0.5\") FROM \"kubelet_pod_worker_latency_microseconds\" WHERE $timeFilter GROUP BY time($interval), \"host\" fill(null)",
-                "refId": "A",
-                "resultFormat": "time_series",
                 "select": [
                   [
                     {
+                      "type": "field",
                       "params": [
                         "0.5"
-                      ],
-                      "type": "field"
+                      ]
                     },
                     {
-                      "params": [],
-                      "type": "last"
+                      "type": "last",
+                      "params": []
                     }
                   ]
                 ],
-                "tags": []
-              },
-              {
-                "alias": "90th",
-                "dsType": "influxdb",
-                "groupBy": [
-                  {
-                    "params": [
-                      "$interval"
-                    ],
-                    "type": "time"
-                  },
-                  {
-                    "params": [
-                      "null"
-                    ],
-                    "type": "fill"
-                  }
-                ],
-                "measurement": "kubelet_pod_worker_latency_microseconds",
-                "policy": "default",
-                "query": "SELECT last(\"0.9\") FROM \"kubelet_pod_worker_latency_microseconds\" WHERE $timeFilter GROUP BY time($interval), \"host\" fill(null)",
-                "refId": "B",
-                "resultFormat": "time_series",
-                "select": [
-                  [
-                    {
-                      "params": [
-                        "0.9"
-                      ],
-                      "type": "field"
-                    },
-                    {
-                      "params": [],
-                      "type": "last"
-                    }
-                  ]
-                ],
-                "tags": []
-              },
-              {
-                "alias": "99th",
-                "dsType": "influxdb",
-                "groupBy": [
-                  {
-                    "params": [
-                      "$interval"
-                    ],
-                    "type": "time"
-                  },
-                  {
-                    "params": [
-                      "null"
-                    ],
-                    "type": "fill"
-                  }
-                ],
-                "measurement": "kubelet_pod_worker_latency_microseconds",
-                "policy": "default",
-                "query": "SELECT last(\"0.99\") FROM \"kubelet_pod_worker_latency_microseconds\" WHERE $timeFilter GROUP BY time($interval), \"host\" fill(null)",
-                "refId": "C",
-                "resultFormat": "time_series",
-                "select": [
-                  [
-                    {
-                      "params": [
-                        "0.99"
-                      ],
-                      "type": "field"
-                    },
-                    {
-                      "params": [],
-                      "type": "last"
-                    }
-                  ]
-                ],
-                "tags": []
+                "refId": "A",
+                "measurement": "apiserver_request_latencies_summary"
               }
             ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Kubelet Pod Worker Latency",
-            "tooltip": {
-              "msResolution": true,
-              "shared": true,
-              "value_type": "cumulative"
-            },
-            "type": "graph",
+            "datasource": null,
+            "renderer": "flot",
+            "yaxes": [
+              {
+                "label": null,
+                "show": true,
+                "logBase": 1,
+                "min": null,
+                "max": null,
+                "format": "ns"
+              },
+              {
+                "label": null,
+                "show": true,
+                "logBase": 1,
+                "min": null,
+                "max": null,
+                "format": "short"
+              }
+            ],
             "xaxis": {
               "show": true
             },
-            "yaxes": [
-              {
-                "format": "µs",
-                "logBase": 1,
-                "max": null,
-                "min": null,
-                "show": true
-              },
-              {
-                "format": "short",
-                "logBase": 1,
-                "max": null,
-                "min": null,
-                "show": true
-              }
-            ]
+            "grid": {
+              "threshold1": null,
+              "threshold2": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "lines": true,
+            "fill": 1,
+            "linewidth": 2,
+            "points": false,
+            "pointradius": 5,
+            "bars": false,
+            "stack": false,
+            "percentage": false,
+            "legend": {
+              "show": false,
+              "values": false,
+              "min": false,
+              "max": false,
+              "current": false,
+              "total": false,
+              "avg": false
+            },
+            "nullPointMode": "connected",
+            "steppedLine": false,
+            "tooltip": {
+              "value_type": "cumulative",
+              "shared": true,
+              "msResolution": true
+            },
+            "timeFrom": null,
+            "timeShift": null,
+            "aliasColors": {},
+            "seriesOverrides": [],
+            "links": []
           }
         ],
         "repeat": "host",

--- a/grafana/rootfs/usr/share/grafana/dashboards/nsq_health.json
+++ b/grafana/rootfs/usr/share/grafana/dashboards/nsq_health.json
@@ -3,498 +3,737 @@
     "id": null,
     "title": "NSQ Health",
     "tags": ["deis"],
+    "originalTitle": "NSQ Health",
     "style": "dark",
     "timezone": "browser",
     "editable": true,
     "hideControls": false,
     "sharedCrosshair": false,
     "rows": [
-     {
-       "collapse": false,
-       "editable": true,
-       "height": "250px",
-       "panels": [
-         {
-           "cacheTimeout": null,
-           "colorBackground": false,
-           "colorValue": false,
-           "colors": [
-             "rgba(245, 54, 54, 0.9)",
-             "rgba(237, 129, 40, 0.89)",
-             "rgba(50, 172, 45, 0.97)"
-           ],
-           "datasource": null,
-           "editable": true,
-           "error": false,
-           "format": "none",
-           "gauge": {
-             "maxValue": 100,
-             "minValue": 0,
-             "show": false,
-             "thresholdLabels": false,
-             "thresholdMarkers": true
-           },
-           "id": 4,
-           "interval": null,
-           "isNew": true,
-           "links": [],
-           "maxDataPoints": 100,
-           "nullPointMode": "connected",
-           "nullText": null,
-           "postfix": "",
-           "postfixFontSize": "50%",
-           "prefix": "",
-           "prefixFontSize": "50%",
-           "span": 6,
-           "sparkline": {
-             "fillColor": "rgba(31, 118, 189, 0.18)",
-             "full": false,
-             "lineColor": "rgb(31, 120, 193)",
-             "show": false
-           },
-           "targets": [
-             {
-               "alias": "",
-               "dsType": "influxdb",
-               "groupBy": [
-                 {
-                   "params": [
-                     "$interval"
-                   ],
-                   "type": "time"
-                 },
-                 {
-                   "params": [
-                     "null"
-                   ],
-                   "type": "fill"
-                 }
-               ],
-               "measurement": "nsq_channel",
-               "policy": "default",
-               "refId": "A",
-               "resultFormat": "time_series",
-               "select": [
-                 [
-                   {
-                     "params": [
-                       "client_count"
-                     ],
-                     "type": "field"
-                   },
-                   {
-                     "params": [],
-                     "type": "mean"
-                   }
-                 ]
-               ],
-               "tags": [
-                 {
-                   "key": "topic",
-                   "operator": "=",
-                   "value": "logs"
-                 }
-               ]
-             }
-           ],
-           "thresholds": "0",
-           "title": "Logs consumers",
-           "type": "singlestat",
-           "valueFontSize": "200%",
-           "valueMaps": [
-             {
-               "op": "=",
-               "text": "N/A",
-               "value": "null"
-             }
-           ],
-           "valueName": "avg"
-         },
-         {
-           "cacheTimeout": null,
-           "colorBackground": false,
-           "colorValue": false,
-           "colors": [
-             "rgba(245, 54, 54, 0.9)",
-             "rgba(237, 129, 40, 0.89)",
-             "rgba(50, 172, 45, 0.97)"
-           ],
-           "datasource": null,
-           "editable": true,
-           "error": false,
-           "format": "none",
-           "gauge": {
-             "maxValue": 100,
-             "minValue": 0,
-             "show": false,
-             "thresholdLabels": false,
-             "thresholdMarkers": true
-           },
-           "id": 5,
-           "interval": null,
-           "isNew": true,
-           "links": [],
-           "maxDataPoints": 100,
-           "nullPointMode": "connected",
-           "nullText": null,
-           "postfix": "",
-           "postfixFontSize": "50%",
-           "prefix": "",
-           "prefixFontSize": "50%",
-           "span": 6,
-           "sparkline": {
-             "fillColor": "rgba(31, 118, 189, 0.18)",
-             "full": false,
-             "lineColor": "rgb(31, 120, 193)",
-             "show": false
-           },
-           "targets": [
-             {
-               "alias": "",
-               "dsType": "influxdb",
-               "groupBy": [
-                 {
-                   "params": [
-                     "$interval"
-                   ],
-                   "type": "time"
-                 },
-                 {
-                   "params": [
-                     "null"
-                   ],
-                   "type": "fill"
-                 }
-               ],
-               "measurement": "nsq_channel",
-               "policy": "default",
-               "refId": "A",
-               "resultFormat": "time_series",
-               "select": [
-                 [
-                   {
-                     "params": [
-                       "client_count"
-                     ],
-                     "type": "field"
-                   },
-                   {
-                     "params": [],
-                     "type": "mean"
-                   }
-                 ]
-               ],
-               "tags": [
-                 {
-                   "key": "topic",
-                   "operator": "=",
-                   "value": "metrics"
-                 }
-               ]
-             }
-           ],
-           "thresholds": "0",
-           "title": "Metric consumers",
-           "type": "singlestat",
-           "valueFontSize": "200%",
-           "valueMaps": [
-             {
-               "op": "=",
-               "text": "N/A",
-               "value": "null"
-             }
-           ],
-           "valueName": "avg"
-         }
-       ],
-       "title": "New row"
-     },
-     {
-       "collapse": false,
-       "editable": true,
-       "height": "250px",
-       "panels": [
-         {
-           "aliasColors": {},
-           "bars": false,
-           "datasource": null,
-           "editable": true,
-           "error": false,
-           "fill": 1,
-           "grid": {
-             "threshold1": null,
-             "threshold1Color": "rgba(216, 200, 27, 0.27)",
-             "threshold2": null,
-             "threshold2Color": "rgba(234, 112, 112, 0.22)"
-           },
-           "id": 1,
-           "isNew": true,
-           "legend": {
-             "avg": false,
-             "current": false,
-             "max": false,
-             "min": false,
-             "show": true,
-             "total": false,
-             "values": false
-           },
-           "lines": true,
-           "linewidth": 2,
-           "links": [],
-           "nullPointMode": "connected",
-           "percentage": false,
-           "pointradius": 5,
-           "points": false,
-           "renderer": "flot",
-           "seriesOverrides": [],
-           "span": 12,
-           "stack": false,
-           "steppedLine": false,
-           "targets": [
-             {
-               "alias": "$tag_topic",
-               "dsType": "influxdb",
-               "groupBy": [
-                 {
-                   "params": [
-                     "$interval"
-                   ],
-                   "type": "time"
-                 },
-                 {
-                   "params": [
-                     "topic"
-                   ],
-                   "type": "tag"
-                 },
-                 {
-                   "params": [
-                     "null"
-                   ],
-                   "type": "fill"
-                 }
-               ],
-               "measurement": "nsq_topic",
-               "policy": "default",
-               "refId": "A",
-               "resultFormat": "time_series",
-               "select": [
-                 [
-                   {
-                     "params": [
-                       "depth"
-                     ],
-                     "type": "field"
-                   },
-                   {
-                     "params": [],
-                     "type": "last"
-                   }
-                 ]
-               ],
-               "tags": []
-             }
-           ],
-           "timeFrom": null,
-           "timeShift": null,
-           "title": "Topic Message Depth",
-           "tooltip": {
-             "msResolution": true,
-             "shared": true,
-             "value_type": "cumulative"
-           },
-           "type": "graph",
-           "xaxis": {
-             "show": true
-           },
-           "yaxes": [
-             {
-               "format": "short",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-             },
-             {
-               "format": "short",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-             }
-           ]
-         }
-       ],
-       "title": "Row"
-     },
-     {
-       "collapse": false,
-       "editable": true,
-       "height": "250px",
-       "panels": [
-         {
-           "title": "Messages Per Second / Topic",
-           "error": false,
-           "span": 12,
-           "editable": true,
-           "type": "graph",
-           "isNew": true,
-           "id": 6,
-           "targets": [
-             {
-               "policy": "default",
-               "dsType": "influxdb",
-               "resultFormat": "time_series",
-               "tags": [],
-               "groupBy": [
-                 {
-                   "type": "time",
-                   "params": [
-                     "$interval"
-                   ]
-                 },
-                 {
-                   "type": "tag",
-                   "params": [
-                     "topic"
-                   ]
-                 },
-                 {
-                   "type": "fill",
-                   "params": [
-                     "null"
-                   ]
-                 }
-               ],
-               "select": [
-                 [
-                   {
-                     "type": "field",
-                     "params": [
-                       "message_count"
-                     ]
-                   },
-                   {
-                     "type": "last",
-                     "params": []
-                   },
-                   {
-                     "type": "non_negative_derivative",
-                     "params": [
-                       "1s"
-                     ]
-                   }
-                 ]
-               ],
-               "refId": "A",
-               "measurement": "nsq_topic",
-               "alias": "$tag_topic"
-             }
-           ],
-           "datasource": null,
-           "renderer": "flot",
-           "yaxes": [
-             {
-               "label": null,
-               "show": true,
-               "logBase": 1,
-               "min": null,
-               "max": null,
-               "format": "short"
-             },
-             {
-               "label": null,
-               "show": true,
-               "logBase": 1,
-               "min": null,
-               "max": null,
-               "format": "short"
-             }
-           ],
-           "xaxis": {
-             "show": true
-           },
-           "grid": {
-             "threshold1": null,
-             "threshold2": null,
-             "threshold1Color": "rgba(216, 200, 27, 0.27)",
-             "threshold2Color": "rgba(234, 112, 112, 0.22)"
-           },
-           "lines": true,
-           "fill": 1,
-           "linewidth": 2,
-           "points": false,
-           "pointradius": 5,
-           "bars": false,
-           "stack": false,
-           "percentage": false,
-           "legend": {
-             "show": true,
-             "values": false,
-             "min": false,
-             "max": false,
-             "current": false,
-             "total": false,
-             "avg": false
-           },
-           "nullPointMode": "connected",
-           "steppedLine": false,
-           "tooltip": {
-             "value_type": "cumulative",
-             "shared": true,
-             "msResolution": true
-           },
-           "timeFrom": null,
-           "timeShift": null,
-           "aliasColors": {},
-           "seriesOverrides": [],
-           "interval": "1s",
-           "links": []
-         }
-       ],
-       "title": "New row"
-     }
+      {
+        "collapse": false,
+        "editable": true,
+        "height": "200px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "id": 7,
+            "isNew": true,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": false,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "dsType": "influxdb",
+                "groupBy": [
+                  {
+                    "params": [
+                      "$interval"
+                    ],
+                    "type": "time"
+                  },
+                  {
+                    "params": [
+                      "null"
+                    ],
+                    "type": "fill"
+                  }
+                ],
+                "measurement": "container_cpu_usage_seconds_total",
+                "policy": "default",
+                "refId": "A",
+                "resultFormat": "time_series",
+                "select": [
+                  [
+                    {
+                      "params": [
+                        "counter"
+                      ],
+                      "type": "field"
+                    },
+                    {
+                      "params": [],
+                      "type": "last"
+                    },
+                    {
+                      "params": [
+                        "10s"
+                      ],
+                      "type": "non_negative_derivative"
+                    }
+                  ]
+                ],
+                "tags": [
+                  {
+                    "key": "kubernetes_container_name",
+                    "operator": "=",
+                    "value": "deis-nsqd"
+                  }
+                ]
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "CPU",
+            "tooltip": {
+              "msResolution": true,
+              "shared": true,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "show": true
+            },
+            "yaxes": [
+              {
+                "format": "s",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "title": "Memory",
+            "error": false,
+            "span": 6,
+            "editable": true,
+            "type": "singlestat",
+            "isNew": true,
+            "id": 8,
+            "targets": [
+              {
+                "policy": "default",
+                "dsType": "influxdb",
+                "resultFormat": "time_series",
+                "tags": [
+                  {
+                    "key": "kubernetes_container_name",
+                    "operator": "=",
+                    "value": "deis-nsqd"
+                  }
+                ],
+                "groupBy": [
+                  {
+                    "type": "time",
+                    "params": [
+                      "$interval"
+                    ]
+                  },
+                  {
+                    "type": "fill",
+                    "params": [
+                      "null"
+                    ]
+                  }
+                ],
+                "select": [
+                  [
+                    {
+                      "type": "field",
+                      "params": [
+                        "gauge"
+                      ]
+                    },
+                    {
+                      "type": "last",
+                      "params": []
+                    }
+                  ]
+                ],
+                "refId": "A",
+                "measurement": "container_memory_usage_bytes"
+              }
+            ],
+            "links": [],
+            "datasource": null,
+            "maxDataPoints": 100,
+            "interval": null,
+            "cacheTimeout": null,
+            "format": "bytes",
+            "prefix": "",
+            "postfix": "",
+            "nullText": null,
+            "valueMaps": [
+              {
+                "value": "null",
+                "op": "=",
+                "text": "N/A"
+              }
+            ],
+            "nullPointMode": "connected",
+            "valueName": "current",
+            "prefixFontSize": "50%",
+            "valueFontSize": "200%",
+            "postfixFontSize": "50%",
+            "thresholds": "",
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+              "rgba(245, 54, 54, 0.9)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(50, 172, 45, 0.97)"
+            ],
+            "sparkline": {
+              "show": false,
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "fillColor": "rgba(31, 118, 189, 0.18)"
+            },
+            "gauge": {
+              "show": false,
+              "minValue": 0,
+              "maxValue": 100,
+              "thresholdMarkers": true,
+              "thresholdLabels": false
+            }
+          }
+        ],
+        "title": "New row"
+      },
+      {
+        "collapse": false,
+        "editable": true,
+        "height": "100px",
+        "panels": [
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+              "rgba(245, 54, 54, 0.9)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(50, 172, 45, 0.97)"
+            ],
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "format": "none",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 4,
+            "interval": null,
+            "isNew": true,
+            "links": [],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "span": 6,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": false
+            },
+            "targets": [
+              {
+                "alias": "",
+                "dsType": "influxdb",
+                "groupBy": [
+                  {
+                    "params": [
+                      "$interval"
+                    ],
+                    "type": "time"
+                  },
+                  {
+                    "params": [
+                      "null"
+                    ],
+                    "type": "fill"
+                  }
+                ],
+                "measurement": "nsq_channel",
+                "policy": "default",
+                "refId": "A",
+                "resultFormat": "time_series",
+                "select": [
+                  [
+                    {
+                      "params": [
+                        "client_count"
+                      ],
+                      "type": "field"
+                    },
+                    {
+                      "params": [],
+                      "type": "mean"
+                    }
+                  ]
+                ],
+                "tags": [
+                  {
+                    "key": "topic",
+                    "operator": "=",
+                    "value": "logs"
+                  }
+                ]
+              }
+            ],
+            "thresholds": "0",
+            "title": "Logs consumers",
+            "type": "singlestat",
+            "valueFontSize": "200%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+              "rgba(245, 54, 54, 0.9)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(50, 172, 45, 0.97)"
+            ],
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "format": "none",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 5,
+            "interval": null,
+            "isNew": true,
+            "links": [],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "span": 6,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": false
+            },
+            "targets": [
+              {
+                "alias": "",
+                "dsType": "influxdb",
+                "groupBy": [
+                  {
+                    "params": [
+                      "$interval"
+                    ],
+                    "type": "time"
+                  },
+                  {
+                    "params": [
+                      "null"
+                    ],
+                    "type": "fill"
+                  }
+                ],
+                "measurement": "nsq_channel",
+                "policy": "default",
+                "refId": "A",
+                "resultFormat": "time_series",
+                "select": [
+                  [
+                    {
+                      "params": [
+                        "client_count"
+                      ],
+                      "type": "field"
+                    },
+                    {
+                      "params": [],
+                      "type": "mean"
+                    }
+                  ]
+                ],
+                "tags": [
+                  {
+                    "key": "topic",
+                    "operator": "=",
+                    "value": "metrics"
+                  }
+                ]
+              }
+            ],
+            "thresholds": "0",
+            "title": "Metric consumers",
+            "type": "singlestat",
+            "valueFontSize": "200%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          }
+        ],
+        "title": "New row"
+      },
+      {
+        "collapse": false,
+        "editable": true,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "id": 1,
+            "isNew": true,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+              {
+                "alias": "logs",
+                "color": "#0A437C"
+              },
+              {
+                "alias": "metrics",
+                "color": "#E5AC0E"
+              }
+            ],
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "alias": "$tag_topic",
+                "dsType": "influxdb",
+                "groupBy": [
+                  {
+                    "params": [
+                      "$interval"
+                    ],
+                    "type": "time"
+                  },
+                  {
+                    "params": [
+                      "topic"
+                    ],
+                    "type": "tag"
+                  },
+                  {
+                    "params": [
+                      "null"
+                    ],
+                    "type": "fill"
+                  }
+                ],
+                "measurement": "nsq_channel",
+                "policy": "default",
+                "refId": "A",
+                "resultFormat": "time_series",
+                "select": [
+                  [
+                    {
+                      "params": [
+                        "depth"
+                      ],
+                      "type": "field"
+                    },
+                    {
+                      "params": [],
+                      "type": "last"
+                    }
+                  ]
+                ],
+                "tags": []
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Topic Message Depth",
+            "tooltip": {
+              "msResolution": true,
+              "shared": true,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "show": true
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "title": "Row"
+      },
+      {
+        "collapse": false,
+        "editable": true,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "id": 6,
+            "interval": "1s",
+            "isNew": true,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+              {
+                "alias": "logs",
+                "color": "#0A437C"
+              },
+              {
+                "alias": "metrics",
+                "color": "#E5AC0E"
+              }
+            ],
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "alias": "$tag_topic",
+                "dsType": "influxdb",
+                "groupBy": [
+                  {
+                    "params": [
+                      "$interval"
+                    ],
+                    "type": "time"
+                  },
+                  {
+                    "params": [
+                      "topic"
+                    ],
+                    "type": "tag"
+                  },
+                  {
+                    "params": [
+                      "null"
+                    ],
+                    "type": "fill"
+                  }
+                ],
+                "measurement": "nsq_topic",
+                "policy": "default",
+                "refId": "A",
+                "resultFormat": "time_series",
+                "select": [
+                  [
+                    {
+                      "params": [
+                        "message_count"
+                      ],
+                      "type": "field"
+                    },
+                    {
+                      "params": [],
+                      "type": "last"
+                    },
+                    {
+                      "params": [
+                        "1s"
+                      ],
+                      "type": "non_negative_derivative"
+                    }
+                  ]
+                ],
+                "tags": []
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Messages Per Second / Topic",
+            "tooltip": {
+              "msResolution": true,
+              "shared": true,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "show": true
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "title": "New row"
+      }
     ],
     "time": {
-     "from": "now-5m",
-     "to": "now"
+      "from": "now-5m",
+      "to": "now"
     },
     "timepicker": {
-     "refresh_intervals": [
-       "5s",
-       "10s",
-       "30s",
-       "1m",
-       "5m",
-       "15m",
-       "30m",
-       "1h",
-       "2h",
-       "1d"
-     ],
-     "time_options": [
-       "5m",
-       "15m",
-       "1h",
-       "6h",
-       "12h",
-       "24h",
-       "2d",
-       "7d",
-       "30d"
-     ]
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ]
     },
     "templating": {
-     "list": []
+      "list": []
     },
     "annotations": {
-     "list": []
+      "list": []
     },
     "refresh": "5s",
     "schemaVersion": 12,
     "version": 0,
     "links": []
-   }
+  }
  }

--- a/grafana/rootfs/usr/share/grafana/dashboards/redis.json
+++ b/grafana/rootfs/usr/share/grafana/dashboards/redis.json
@@ -2,6 +2,7 @@
   "dashboard": {
     "id": null,
     "title": "Redis",
+    "originalTitle": "Redis",
     "tags": ["deis"],
     "style": "dark",
     "timezone": "browser",
@@ -9,470 +10,460 @@
     "hideControls": false,
     "sharedCrosshair": false,
     "rows": [
-     {
-       "collapse": false,
-       "editable": true,
-       "height": "250px",
-       "panels": [
-         {
-           "cacheTimeout": null,
-           "colorBackground": false,
-           "colorValue": false,
-           "colors": [
-             "rgba(245, 54, 54, 0.9)",
-             "rgba(237, 129, 40, 0.89)",
-             "rgba(50, 172, 45, 0.97)"
-           ],
-           "datasource": null,
-           "editable": true,
-           "error": false,
-           "format": "none",
-           "gauge": {
-             "maxValue": 100,
-             "minValue": 0,
-             "show": false,
-             "thresholdLabels": false,
-             "thresholdMarkers": true
-           },
-           "id": 2,
-           "interval": null,
-           "isNew": true,
-           "links": [],
-           "maxDataPoints": 100,
-           "nullPointMode": "connected",
-           "nullText": null,
-           "postfix": "",
-           "postfixFontSize": "50%",
-           "prefix": "",
-           "prefixFontSize": "50%",
-           "span": 6,
-           "sparkline": {
-             "fillColor": "rgba(31, 118, 189, 0.18)",
-             "full": false,
-             "lineColor": "rgb(31, 120, 193)",
-             "show": false
-           },
-           "targets": [
-             {
-               "dsType": "influxdb",
-               "groupBy": [
-                 {
-                   "params": [
-                     "$interval"
-                   ],
-                   "type": "time"
-                 },
-                 {
-                   "params": [
-                     "null"
-                   ],
-                   "type": "fill"
-                 }
-               ],
-               "measurement": "redis",
-               "policy": "default",
-               "refId": "A",
-               "resultFormat": "time_series",
-               "select": [
-                 [
-                   {
-                     "params": [
-                       "clients"
-                     ],
-                     "type": "field"
-                   },
-                   {
-                     "params": [],
-                     "type": "last"
-                   }
-                 ]
-               ],
-               "tags": []
-             }
-           ],
-           "thresholds": "",
-           "title": "Connected Clients",
-           "type": "singlestat",
-           "valueFontSize": "200%",
-           "valueMaps": [
-             {
-               "op": "=",
-               "text": "N/A",
-               "value": "null"
-             }
-           ],
-           "valueName": "avg"
-         },
-         {
-           "aliasColors": {},
-           "bars": false,
-           "datasource": null,
-           "editable": true,
-           "error": false,
-           "fill": 1,
-           "grid": {
-             "threshold1": null,
-             "threshold1Color": "rgba(216, 200, 27, 0.27)",
-             "threshold2": null,
-             "threshold2Color": "rgba(234, 112, 112, 0.22)"
-           },
-           "id": 1,
-           "isNew": true,
-           "legend": {
-             "avg": false,
-             "current": false,
-             "max": false,
-             "min": false,
-             "show": false,
-             "total": false,
-             "values": false
-           },
-           "lines": true,
-           "linewidth": 2,
-           "links": [],
-           "nullPointMode": "connected",
-           "percentage": false,
-           "pointradius": 5,
-           "points": false,
-           "renderer": "flot",
-           "seriesOverrides": [],
-           "span": 6,
-           "stack": false,
-           "steppedLine": false,
-           "targets": [
-             {
-               "alias": "Used",
-               "dsType": "influxdb",
-               "groupBy": [
-                 {
-                   "params": [
-                     "$interval"
-                   ],
-                   "type": "time"
-                 },
-                 {
-                   "params": [
-                     "null"
-                   ],
-                   "type": "fill"
-                 }
-               ],
-               "measurement": "redis",
-               "policy": "default",
-               "refId": "A",
-               "resultFormat": "time_series",
-               "select": [
-                 [
-                   {
-                     "params": [
-                       "used_memory"
-                     ],
-                     "type": "field"
-                   },
-                   {
-                     "params": [],
-                     "type": "last"
-                   }
-                 ]
-               ],
-               "tags": []
-             }
-           ],
-           "timeFrom": null,
-           "timeShift": null,
-           "title": "Memory",
-           "tooltip": {
-             "msResolution": true,
-             "shared": true,
-             "value_type": "cumulative"
-           },
-           "type": "graph",
-           "xaxis": {
-             "show": true
-           },
-           "yaxes": [
-             {
-               "format": "bytes",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-             },
-             {
-               "format": "short",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-             }
-           ]
-         }
-       ],
-       "title": "New row"
-     },
-     {
-       "collapse": false,
-       "editable": true,
-       "height": "250px",
-       "panels": [
-         {
-           "aliasColors": {},
-           "bars": false,
-           "datasource": null,
-           "editable": true,
-           "error": false,
-           "fill": 1,
-           "grid": {
-             "threshold1": null,
-             "threshold1Color": "rgba(216, 200, 27, 0.27)",
-             "threshold2": null,
-             "threshold2Color": "rgba(234, 112, 112, 0.22)"
-           },
-           "id": 3,
-           "isNew": true,
-           "legend": {
-             "avg": false,
-             "current": false,
-             "max": false,
-             "min": false,
-             "show": false,
-             "total": false,
-             "values": false
-           },
-           "lines": true,
-           "linewidth": 2,
-           "links": [],
-           "nullPointMode": "connected",
-           "percentage": false,
-           "pointradius": 5,
-           "points": false,
-           "renderer": "flot",
-           "seriesOverrides": [],
-           "span": 6,
-           "stack": false,
-           "steppedLine": false,
-           "targets": [
-             {
-               "dsType": "influxdb",
-               "groupBy": [
-                 {
-                   "params": [
-                     "$interval"
-                   ],
-                   "type": "time"
-                 },
-                 {
-                   "params": [
-                     "null"
-                   ],
-                   "type": "fill"
-                 }
-               ],
-               "measurement": "container_cpu_usage_seconds_total",
-               "policy": "default",
-               "refId": "A",
-               "resultFormat": "time_series",
-               "select": [
-                 [
-                   {
-                     "params": [
-                       "counter"
-                     ],
-                     "type": "field"
-                   },
-                   {
-                     "params": [],
-                     "type": "last"
-                   },
-                   {
-                     "params": [
-                       "1s"
-                     ],
-                     "type": "non_negative_derivative"
-                   }
-                 ]
-               ],
-               "tags": []
-             }
-           ],
-           "timeFrom": null,
-           "timeShift": null,
-           "title": "CPU",
-           "tooltip": {
-             "msResolution": true,
-             "shared": true,
-             "value_type": "cumulative"
-           },
-           "type": "graph",
-           "xaxis": {
-             "show": true
-           },
-           "yaxes": [
-             {
-               "format": "s",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-             },
-             {
-               "format": "short",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-             }
-           ]
-         },
-         {
-           "aliasColors": {},
-           "bars": false,
-           "datasource": null,
-           "editable": true,
-           "error": false,
-           "fill": 1,
-           "grid": {
-             "threshold1": null,
-             "threshold1Color": "rgba(216, 200, 27, 0.27)",
-             "threshold2": null,
-             "threshold2Color": "rgba(234, 112, 112, 0.22)"
-           },
-           "id": 4,
-           "interval": "1s",
-           "isNew": true,
-           "legend": {
-             "avg": false,
-             "current": false,
-             "max": false,
-             "min": false,
-             "show": false,
-             "total": false,
-             "values": false
-           },
-           "lines": true,
-           "linewidth": 2,
-           "links": [],
-           "nullPointMode": "connected",
-           "percentage": false,
-           "pointradius": 5,
-           "points": false,
-           "renderer": "flot",
-           "seriesOverrides": [],
-           "span": 6,
-           "stack": false,
-           "steppedLine": false,
-           "targets": [
-             {
-               "dsType": "influxdb",
-               "groupBy": [
-                 {
-                   "params": [
-                     "$interval"
-                   ],
-                   "type": "time"
-                 },
-                 {
-                   "params": [
-                     "null"
-                   ],
-                   "type": "fill"
-                 }
-               ],
-               "measurement": "redis",
-               "policy": "default",
-               "refId": "A",
-               "resultFormat": "time_series",
-               "select": [
-                 [
-                   {
-                     "params": [
-                       "instantaneous_ops_per_sec"
-                     ],
-                     "type": "field"
-                   },
-                   {
-                     "params": [],
-                     "type": "last"
-                   }
-                 ]
-               ],
-               "tags": []
-             }
-           ],
-           "timeFrom": null,
-           "timeShift": null,
-           "title": "Ops Per Second",
-           "tooltip": {
-             "msResolution": true,
-             "shared": true,
-             "value_type": "cumulative"
-           },
-           "type": "graph",
-           "xaxis": {
-             "show": true
-           },
-           "yaxes": [
-             {
-               "format": "ops",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-             },
-             {
-               "format": "short",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-             }
-           ]
-         }
-       ],
-       "title": "Row"
-     }
+      {
+        "collapse": false,
+        "editable": true,
+        "height": "100px",
+        "panels": [
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+              "rgba(245, 54, 54, 0.9)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(50, 172, 45, 0.97)"
+            ],
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "format": "none",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 2,
+            "interval": null,
+            "isNew": true,
+            "links": [],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "span": 6,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": false
+            },
+            "targets": [
+              {
+                "dsType": "influxdb",
+                "groupBy": [
+                  {
+                    "params": [
+                      "$interval"
+                    ],
+                    "type": "time"
+                  },
+                  {
+                    "params": [
+                      "null"
+                    ],
+                    "type": "fill"
+                  }
+                ],
+                "measurement": "redis",
+                "policy": "default",
+                "refId": "A",
+                "resultFormat": "time_series",
+                "select": [
+                  [
+                    {
+                      "params": [
+                        "clients"
+                      ],
+                      "type": "field"
+                    },
+                    {
+                      "params": [],
+                      "type": "last"
+                    }
+                  ]
+                ],
+                "tags": []
+              }
+            ],
+            "thresholds": "",
+            "title": "Connected Clients",
+            "type": "singlestat",
+            "valueFontSize": "200%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg"
+          },
+          {
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+              "rgba(245, 54, 54, 0.9)",
+              "rgba(237, 129, 40, 0.89)",
+              "rgba(50, 172, 45, 0.97)"
+            ],
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "format": "bytes",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "id": 5,
+            "interval": null,
+            "isNew": true,
+            "links": [],
+            "maxDataPoints": 100,
+            "nullPointMode": "connected",
+            "nullText": null,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "span": 6,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": false
+            },
+            "targets": [
+              {
+                "dsType": "influxdb",
+                "groupBy": [
+                  {
+                    "params": [
+                      "$interval"
+                    ],
+                    "type": "time"
+                  },
+                  {
+                    "params": [
+                      "null"
+                    ],
+                    "type": "fill"
+                  }
+                ],
+                "measurement": "container_memory_usage_bytes",
+                "policy": "default",
+                "refId": "A",
+                "resultFormat": "time_series",
+                "select": [
+                  [
+                    {
+                      "params": [
+                        "gauge"
+                      ],
+                      "type": "field"
+                    },
+                    {
+                      "params": [],
+                      "type": "last"
+                    }
+                  ]
+                ],
+                "tags": [
+                  {
+                    "key": "kubernetes_container_name",
+                    "operator": "=",
+                    "value": "deis-logger-redis"
+                  }
+                ]
+              }
+            ],
+            "thresholds": "",
+            "title": "Memory",
+            "type": "singlestat",
+            "valueFontSize": "200%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "current"
+          }
+        ],
+        "title": "New row"
+      },
+      {
+        "collapse": false,
+        "editable": true,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "id": 3,
+            "isNew": true,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": false,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "dsType": "influxdb",
+                "groupBy": [
+                  {
+                    "params": [
+                      "$interval"
+                    ],
+                    "type": "time"
+                  },
+                  {
+                    "params": [
+                      "null"
+                    ],
+                    "type": "fill"
+                  }
+                ],
+                "measurement": "container_cpu_usage_seconds_total",
+                "policy": "default",
+                "refId": "A",
+                "resultFormat": "time_series",
+                "select": [
+                  [
+                    {
+                      "params": [
+                        "counter"
+                      ],
+                      "type": "field"
+                    },
+                    {
+                      "params": [],
+                      "type": "last"
+                    },
+                    {
+                      "params": [
+                        "1s"
+                      ],
+                      "type": "non_negative_derivative"
+                    }
+                  ]
+                ],
+                "tags": []
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "CPU",
+            "tooltip": {
+              "msResolution": true,
+              "shared": true,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "show": true
+            },
+            "yaxes": [
+              {
+                "format": "s",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": null,
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "id": 4,
+            "interval": "1s",
+            "isNew": true,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": false,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "dsType": "influxdb",
+                "groupBy": [
+                  {
+                    "params": [
+                      "$interval"
+                    ],
+                    "type": "time"
+                  },
+                  {
+                    "params": [
+                      "null"
+                    ],
+                    "type": "fill"
+                  }
+                ],
+                "measurement": "redis",
+                "policy": "default",
+                "refId": "A",
+                "resultFormat": "time_series",
+                "select": [
+                  [
+                    {
+                      "params": [
+                        "instantaneous_ops_per_sec"
+                      ],
+                      "type": "field"
+                    },
+                    {
+                      "params": [],
+                      "type": "last"
+                    }
+                  ]
+                ],
+                "tags": []
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Ops Per Second",
+            "tooltip": {
+              "msResolution": true,
+              "shared": true,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "show": true
+            },
+            "yaxes": [
+              {
+                "format": "ops",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "title": "Row"
+      }
     ],
     "time": {
-     "from": "now-5m",
-     "to": "now"
+      "from": "now-5m",
+      "to": "now"
     },
     "timepicker": {
-     "refresh_intervals": [
-       "5s",
-       "10s",
-       "30s",
-       "1m",
-       "5m",
-       "15m",
-       "30m",
-       "1h",
-       "2h",
-       "1d"
-     ],
-     "time_options": [
-       "5m",
-       "15m",
-       "1h",
-       "6h",
-       "12h",
-       "24h",
-       "2d",
-       "7d",
-       "30d"
-     ]
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ]
     },
     "templating": {
-     "list": []
+      "list": []
     },
     "annotations": {
-     "list": []
+      "list": []
     },
+    "refresh": "5s",
     "schemaVersion": 12,
     "version": 0,
     "links": []


### PR DESCRIPTION
- NSQ - Add cpu and memory usage, update color values for message topic depth and messages per second
- Deis Health - Aggregate CPU usage across all containers of a similar pod name
- Deis Router - Add CPU and Memory, update location of certain graphs
- Influx - Updated memory usage and disk usage to be single stat graphs
- Kubernetes Health - Add aggregate pod memory usage and api resource summary latency graphs
- Redis - Make memory a single stat panel

Testing:
- Have fresh cluster with latest redis changes
- `make build push upgrade` in grafana directory
- Login `grafana.mydomain.com` `admin/admin`
- Verify all dashboards are present (listed above) 
- Make sure values are flowing into the graphs
