### PR TITLE
fix(ini): a stray quote was causing INI parsing to break

### DIFF
--- a/grafana/rootfs/usr/share/grafana/grafana.ini.tpl
+++ b/grafana/rootfs/usr/share/grafana/grafana.ini.tpl
@@ -205,7 +205,7 @@ allowed_domains = {{ default "" .GOOGLE_AUTH_ALLOWED_DOMAINS }}
 [auth.proxy]
 {{ if .AUTH_PROXY }}
 enabled = {{ .AUTH_PROXY }}
-header_name = {{ default "X-WEBAUTH-USER" .AUTH_HEADER_NAME" }}
+header_name = {{ default "X-WEBAUTH-USER" .AUTH_HEADER_NAME }}
 header_property = {{ default "username" .AUTH_HEADER_PROPERTY }}
 auto_sign_up = {{ default "true" .AUTH_AUTO_SIGN_UP }}
 {{ end }}


### PR DESCRIPTION
Error: parsing template grafana.ini.tpl (template: grafana.ini.tpl:208: bad character U+0022 '"')
