### PR TITLE
fix(start-grafana): Create dashboard directory when starting grafana

### DIFF
--- a/grafana/rootfs/usr/share/grafana/start-grafana
+++ b/grafana/rootfs/usr/share/grafana/start-grafana
@@ -15,6 +15,8 @@ INFLUXDB_USER=${INFLUXDB_USER:-admin}
 INFLUXDB_PASSWORD=${INFLUXDB_PASSWORD:-admin}
 
 DASHBOARD_LOCATION=${DASHBOARD_JSON_PATH:-"/usr/share/grafana/api/dashboards"}
+# Create the dashboards directory
+mkdir /usr/share/grafana/dashboards
 
 echo "Building grafana.ini!"
 ./envtpl -in grafana.ini.tpl >> grafana.ini


### PR DESCRIPTION
closes #129
