### PR TITLE
fix(grafana,telegraf): make curl fail on unsuccessful HTTP codes

### DIFF
--- a/grafana/rootfs/Dockerfile
+++ b/grafana/rootfs/Dockerfile
@@ -4,9 +4,9 @@ COPY . /
 
 RUN apt-get update && \
 	apt-get install -y libfontconfig && \
-	curl -sL -o /usr/share/grafana/envtpl https://github.com/arschles/envtpl/releases/download/0.2.3/envtpl_linux_amd64 && \
+	curl -fsSL -o /usr/share/grafana/envtpl https://github.com/arschles/envtpl/releases/download/0.2.3/envtpl_linux_amd64 && \
 	chmod +x /usr/share/grafana/envtpl && \
-	curl -so /tmp/grafana.deb https://grafanarel.s3.amazonaws.com/builds/grafana_3.1.0-1468321182_amd64.deb && \
+	curl -fsSo /tmp/grafana.deb https://grafanarel.s3.amazonaws.com/builds/grafana_3.1.0-1468321182_amd64.deb && \
 	dpkg -i /tmp/grafana.deb && \
 	rm /tmp/grafana.deb && \
 	rm /etc/grafana/grafana.ini && \

--- a/telegraf/rootfs/Dockerfile
+++ b/telegraf/rootfs/Dockerfile
@@ -4,14 +4,14 @@ COPY . /
 
 RUN mkdir -p /usr/local/bin/ \
   # This will come back once the kuberentes plugin is release in November
-  # && curl -SL -o /tmp/telegraf.deb https://dl.influxdata.com/telegraf/releases/telegraf_1.0.0_amd64.deb \
+  # && curl -fsSL -o /tmp/telegraf.deb https://dl.influxdata.com/telegraf/releases/telegraf_1.0.0_amd64.deb \
   # && dpkg -i /tmp/telegraf.deb \
   # && rm /tmp/telegraf.deb \
-  && curl -sSL -o /usr/bin/telegraf https://storage.googleapis.com/telegraf/telegraf \
+  && curl -fsSL -o /usr/bin/telegraf https://storage.googleapis.com/telegraf/telegraf \
   && chmod +x /usr/bin/telegraf \
-	&& curl -sSL -o /usr/bin/envtpl https://github.com/arschles/envtpl/releases/download/0.2.3/envtpl_linux_amd64 \
+	&& curl -fsSL -o /usr/bin/envtpl https://github.com/arschles/envtpl/releases/download/0.2.3/envtpl_linux_amd64 \
 	&& chmod +x /usr/bin/envtpl \
-  && curl -Ls -o /usr/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
+  && curl -fsSL -o /usr/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
   && chmod +x /usr/bin/jq
 
 CMD ["/start-telegraf"]


### PR DESCRIPTION
Adds the `-f` flag to `curl` downloads to avoid the possibility of creating a file with contents like:

``` shell
$ cat /usr/bin/telegraf 
<?xml version='1.0' encoding='UTF-8'?><Error><Code>AccessDenied</Code><Message>Access denied.</Message><Details>Anonymous users does not have storage.objects.get access to object telegraf/telegraf.</Details></Error>
```

See #156. Thanks to @felixbuenemann for suggesting the fix!
