### PR TITLE
Quote INFLUXDB_URLS in Telegraf config

### DIFF
--- a/telegraf/rootfs/config.toml.tpl
+++ b/telegraf/rootfs/config.toml.tpl
@@ -56,7 +56,7 @@
 
 {{ if .INFLUXDB_URLS}}
 [[outputs.influxdb]]
-  urls = [{{ .INFLUXDB_URLS }}]
+  urls = [{{ .INFLUXDB_URLS | quote }}]
   database = {{default "kubernetes" .INFLUXDB_DATABASE | quote }}
   precision = {{ default "ns" .INFLUXDB_PRECISION | quote }}
   timeout = {{ default "5s" .INFLUXDB_TIMEOUT | quote }}


### PR DESCRIPTION
Just installed Workflow 2.9 with an off-cluster InfluxDB and Telegraf won't start because of a parse error in `config.toml` on line 17. The contents are:

```toml
# Set Tag Configuration
[tags]
# Set Agent Configuration
[agent]
  interval = "10s"
  round_interval = true
  metric_buffer_limit = 100000
  collection_jitter = "1s"
  flush_interval = "1s"
  flush_jitter = "0s"
  debug = false
  quiet = true
  flush_buffer_when_full = true
  hostname = "..." 
# Set output configuration
[[outputs.influxdb]]
  urls = [10.15.0.1]
  database = "deis"
  precision = "ns"
  timeout = "5s"
   username = "deis" 
   password = "..." 
#...
```

When configured InfluxDB as off-cluster, its URL is mounted from a secret and so it does not have quotes around it. Thus, a the `quote` filter is needed.
I am not sure, though, whether this breaks the case when InfluxDB is on-cluster as then the URL seems to be quoted.