### PR TITLE
fix(influx, grafana): Add logic around pvc storage class

### DIFF
--- a/charts/monitor/charts/grafana/templates/monitor-grafana-pvc.yaml
+++ b/charts/monitor/charts/grafana/templates/monitor-grafana-pvc.yaml
@@ -6,7 +6,11 @@ metadata:
   labels:
     heritage: deis
   annotations:
-    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass }}
+  {{- if .Values.persistence.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}

--- a/charts/monitor/charts/influxdb/templates/monitor-influxdb-pvc.yaml
+++ b/charts/monitor/charts/influxdb/templates/monitor-influxdb-pvc.yaml
@@ -6,7 +6,11 @@ metadata:
   labels:
     heritage: deis
   annotations:
-    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass }}
+  {{- if .Values.persistence.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}

--- a/charts/monitor/values.yaml
+++ b/charts/monitor/values.yaml
@@ -6,7 +6,6 @@ grafana:
   # limits_memory: "50Mi"
   persistence:
     enabled: false
-    storageClass: standard
     accessMode: ReadWriteOnce
     size: 5Gi
 influxdb:
@@ -21,7 +20,6 @@ influxdb:
   password: "password"
   persistence:
     enabled: false
-    storageClass: standard
     accessMode: ReadWriteOnce
     size: 20Gi
 telegraf:


### PR DESCRIPTION
Starting with 1.5.* kubernetes does not provision a storage class. This means when using the volume.beta.kubernetes.io/storage-class the underlying persistent volume cannot be provisioned. Instead, we must use the old volume.alpha.kubernetes.io/storage-class which when passed a value will automatically provision the storage class and the underlying pv