### PR TITLE
fix(telegraf) ensure off-cluster influxdb url is quoted

### DIFF
--- a/telegraf/rootfs/start-telegraf
+++ b/telegraf/rootfs/start-telegraf
@@ -29,6 +29,11 @@ if [ -n "$ENABLE_PROMETHEUS" ]; then
   echo "Setting PROMETHEUS_URLS: $PROMETHEUS_URLS"
 fi
 
+# if the influxdb url does not start with a quote, assume it's singular and quote it
+if [ ${INFLUXDB_URLS:0:1} != "\"" ]; then
+  export INFLUXDB_URLS="\"$INFLUXDB_URLS\""
+fi
+
 echo "Building config.toml!"
 envtpl -in config.toml.tpl | sed  '/^$/d' > config.toml
 


### PR DESCRIPTION
When using an off-cluster influxdb, the `outputs.influxdb.urls` array is set improperly, as the singular config value is pulled from the secret and not quoted. See below:
```
Building config.toml!
Finished building toml...
###########################################
###########################################
...
[[outputs.influxdb]]
  urls = [https://influx01:8086]
  database = "deis"
  precision = "ns"
  timeout = "5s"
   username = "deis" 
   password = "..." 
 ...
###########################################
###########################################
2017/03/13 04:49:40 E! Error parsing config.toml, toml: line 17: parse error
```

This could be fixed a few ways. The safest and most strait-forward would be to only allow a single url and executing the `| quote` filter on the value. However, it appears the original author intended on keeping the ability to add multiple urls. This fix, although slightly hack-ish, allows for proper handling of the off-cluster influx configuration or the quoted default (or other) configuration.