### PR TITLE
feat(grafana): Allow users to set signup flag in chart

### DIFF
--- a/charts/monitor/charts/grafana/templates/monitor-grafana-deployment.yaml
+++ b/charts/monitor/charts/grafana/templates/monitor-grafana-deployment.yaml
@@ -68,6 +68,8 @@ spec:
           value: {{.Values.user}}
         - name: "DEFAULT_USER_PASSWORD"
           value: {{.Values.password}}
+        - name: "ALLOW_SIGN_UP"
+          value: {{.Values.allow_sign_up | quote}}
         ports:
         - containerPort: 3500
           name: ui

--- a/charts/monitor/values.yaml
+++ b/charts/monitor/values.yaml
@@ -2,6 +2,7 @@ grafana:
   org: "deisci"
   pull_policy: "Always"
   docker_tag: canary
+  allow_sign_up: "true"
   # limits_cpu: "100m"
   # limits_memory: "50Mi"
   persistence:


### PR DESCRIPTION
This PR allows a user to set the `allow_sign_up` flag directly in the chart.

## Testing Steps
### Installing with sign up enabled
* You can either use the master chart or this PR with the default settings
* Go to `grafana.mydomain.com` and click the `Sign Up` tab at the top of the login box and create a user.

### Install with signup flag disabled
* Using this PR do `helm upgrade deis-monitor . --namespace=deis --set grafana.allow_sign_up=false`
* Verify that you the `Sign Up` tab is now unavailable in the login box
