### PR TITLE
RBAC support

### DIFF
--- a/charts/monitor/charts/telegraf/templates/monitor-telegraf-role.yaml
+++ b/charts/monitor/charts/telegraf/templates/monitor-telegraf-role.yaml
@@ -1,0 +1,15 @@
+{{- if (.Values.global.use_rbac) -}}
+{{- if (.Capabilities.APIVersions.Has (include "rbacAPIVersion" .)) -}}
+kind: Role
+apiVersion: {{ template "rbacAPIVersion" . }}
+metadata:
+  name: deis-monitor-telegraf
+  labels:
+    app: deis-monitor-telegraf
+    heritage: deis
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get"]
+{{- end -}}
+{{- end -}}

--- a/charts/monitor/charts/telegraf/templates/monitor-telegraf-rolebinding.yaml
+++ b/charts/monitor/charts/telegraf/templates/monitor-telegraf-rolebinding.yaml
@@ -1,0 +1,18 @@
+{{- if (.Values.global.use_rbac) -}}
+{{- if (.Capabilities.APIVersions.Has (include "rbacAPIVersion" .)) -}}
+kind: RoleBinding
+apiVersion: {{ template "rbacAPIVersion" . }}
+metadata:
+  name: deis-monitor-telegraf
+  labels:
+    app: deis-monitor-telegraf
+    heritage: deis
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: deis-monitor-telegraf
+subjects:
+- kind: ServiceAccount
+  name: deis-monitor-telegraf
+{{- end -}}
+{{- end -}}

--- a/charts/monitor/templates/_helpers.tmpl
+++ b/charts/monitor/templates/_helpers.tmpl
@@ -1,0 +1,10 @@
+{{/*
+Set apiVersion based on Kubernetes version
+*/}}
+{{- define "rbacAPIVersion" -}}
+{{- if ge .Capabilities.KubeVersion.Minor "6" -}}
+rbac.authorization.k8s.io/v1beta1
+{{- else -}}
+rbac.authorization.k8s.io/v1alpha1
+{{- end -}}
+{{- end -}}

--- a/charts/monitor/values.yaml
+++ b/charts/monitor/values.yaml
@@ -49,3 +49,5 @@ global:
   # - on-cluster: Run Redis within the Kubernetes cluster
   # - off-cluster: Run Redis outside the Kubernetes cluster (configure in loggerRedis section)
   logger_redis_location: "on-cluster"
+  # Role-Based Access Control for Kubernetes >= 1.5
+  use_rbac: false


### PR DESCRIPTION
With this change `deis-monitor-telegraf` became available to work in **RBAC**-only clusters

Works with both Kubernetes 1.5 and 1.6 (see `templates/_helpers.tmpl` for details)
Actually tested with 1.5.7 and 1.6.2

ClusterRole allows `deis-monitor-telegraf`:

- `pods`: `get`